### PR TITLE
Add airport codes as name variants

### DIFF
--- a/data/102/541/567/102541567.geojson
+++ b/data/102/541/567/102541567.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"140.371666667,40.1919444444,140.371666667,40.1919444444",
+    "geom:bbox":"140.371667,40.191944,140.371667,40.191944",
     "geom:latitude":40.191944,
     "geom:longitude":140.371667,
     "iso:country":"JP",
@@ -18,6 +18,10 @@
     ],
     "name:eng_x_preferred":[
         "Odate-Noshiro Airport"
+    ],
+    "name:eng_x_variant":[
+        "ONJ",
+        "RJSR"
     ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0627\u0648\u062f\u0627\u062a\u0647-\u0646\u0648\u0634\u06cc\u0631\u0648"
@@ -68,7 +72,7 @@
         "wd:id":"Q1016960"
     },
     "wof:country":"JP",
-    "wof:geomhash":"a309e3146f66cd50341e23c95cd87302",
+    "wof:geomhash":"dcfe8f3ca8ecb4d12e70a0c275775bfe",
     "wof:hierarchy":[
         {
             "campus_id":102541567,
@@ -77,7 +81,7 @@
         }
     ],
     "wof:id":102541567,
-    "wof:lastmodified":1566724946,
+    "wof:lastmodified":1631733561,
     "wof:name":"\u5927\u9928\u80fd\u4ee3\u7a7a\u6e2f",
     "wof:parent_id":85672825,
     "wof:placetype":"campus",
@@ -89,10 +93,10 @@
     ]
 },
   "bbox": [
-    140.37166666667,
-    40.191944444444,
-    140.37166666667,
-    40.191944444444
+    140.371667,
+    40.191944,
+    140.371667,
+    40.191944
 ],
-  "geometry": {"coordinates":[140.37166666667,40.191944444444],"type":"Point"}
+  "geometry": {"coordinates":[140.371667,40.191944],"type":"Point"}
 }

--- a/data/102/541/591/102541591.geojson
+++ b/data/102/541/591/102541591.geojson
@@ -48,7 +48,8 @@
         "HND",
         "KHND",
         "Haneda Airport",
-        "Tokyo Haneda Airport"
+        "Tokyo Haneda Airport",
+        "RJTT"
     ],
     "name:epo_x_preferred":[
         "Internacia Flughaveno Tokio"
@@ -218,7 +219,7 @@
         }
     ],
     "wof:id":102541591,
-    "wof:lastmodified":1578518580,
+    "wof:lastmodified":1631733561,
     "wof:name":"Tokyo Haneda Airport",
     "wof:parent_id":85911187,
     "wof:placetype":"campus",

--- a/data/102/541/607/102541607.geojson
+++ b/data/102/541/607/102541607.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"143.217222222,42.7333333333,143.217222222,42.7333333333",
+    "geom:bbox":"143.217222,42.733333,143.217222,42.733333",
     "geom:latitude":42.733333,
     "geom:longitude":143.217222,
     "iso:country":"JP",
@@ -21,6 +21,10 @@
     ],
     "name:eng_x_preferred":[
         "Tokachi-Obihiro Airport"
+    ],
+    "name:eng_x_variant":[
+        "OBO",
+        "RJCB"
     ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u062a\u0648\u06a9\u0627\u0686\u06cc-\u0627\u0648\u0628\u06cc\u0647\u06cc\u0631\u0648"
@@ -77,7 +81,7 @@
         "wd:id":"Q1332254"
     },
     "wof:country":"JP",
-    "wof:geomhash":"da35a9bc2eaa5ed450a13e3ae63a85f0",
+    "wof:geomhash":"d70ccb19bf88cee1b4fe8f4d8963a7d6",
     "wof:hierarchy":[
         {
             "campus_id":102541607,
@@ -86,7 +90,7 @@
         }
     ],
     "wof:id":102541607,
-    "wof:lastmodified":1566724947,
+    "wof:lastmodified":1631733561,
     "wof:name":"\u5e2f\u5e83\u7a7a\u6e2f",
     "wof:parent_id":85672761,
     "wof:placetype":"campus",
@@ -98,10 +102,10 @@
     ]
 },
   "bbox": [
-    143.21722222222,
-    42.733333333333,
-    143.21722222222,
-    42.733333333333
+    143.217222,
+    42.733333,
+    143.217222,
+    42.733333
 ],
-  "geometry": {"coordinates":[143.21722222221999,42.733333333333],"type":"Point"}
+  "geometry": {"coordinates":[143.21722199999999,42.733333],"type":"Point"}
 }

--- a/data/102/541/661/102541661.geojson
+++ b/data/102/541/661/102541661.geojson
@@ -17,6 +17,10 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":13.0,
+    "name:eng_x_variant":[
+        "KIX",
+        "RJBB"
+    ],
     "name:jap_x_preferred":[
         "\u95a2\u897f\u56fd\u969b\u7a7a\u6e2f"
     ],
@@ -65,7 +69,7 @@
         }
     ],
     "wof:id":102541661,
-    "wof:lastmodified":1578518759,
+    "wof:lastmodified":1631733561,
     "wof:name":"Kansai International Airport",
     "wof:parent_id":-1,
     "wof:placetype":"campus",

--- a/data/102/541/683/102541683.geojson
+++ b/data/102/541/683/102541683.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"135.364444444,33.6622222222,135.364444444,33.6622222222",
+    "geom:bbox":"135.364444,33.662222,135.364444,33.662222",
     "geom:latitude":33.662222,
     "geom:longitude":135.364444,
     "iso:country":"JP",
@@ -18,6 +18,10 @@
     ],
     "name:eng_x_preferred":[
         "Nanki-Shirahama Airport"
+    ],
+    "name:eng_x_variant":[
+        "SHM",
+        "RJBD"
     ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0646\u0627\u0646\u06a9\u06cc\u2013\u0634\u06cc\u0631\u0627\u0647\u0627\u0645\u0627"
@@ -72,7 +76,7 @@
         "wd:id":"Q1064050"
     },
     "wof:country":"JP",
-    "wof:geomhash":"e73c5db3ff10dfd3283e85dbf3bfb9e6",
+    "wof:geomhash":"f325130c7d7e1c0ceaf5feb15415310d",
     "wof:hierarchy":[
         {
             "campus_id":102541683,
@@ -81,7 +85,7 @@
         }
     ],
     "wof:id":102541683,
-    "wof:lastmodified":1566724947,
+    "wof:lastmodified":1631733561,
     "wof:name":"\u5357\u7d00\u767d\u6d5c\u7a7a\u6e2f",
     "wof:parent_id":85672795,
     "wof:placetype":"campus",
@@ -93,10 +97,10 @@
     ]
 },
   "bbox": [
-    135.36444444444,
-    33.662222222222,
-    135.36444444444,
-    33.662222222222
+    135.364444,
+    33.662222,
+    135.364444,
+    33.662222
 ],
-  "geometry": {"coordinates":[135.36444444444001,33.662222222222],"type":"Point"}
+  "geometry": {"coordinates":[135.36444399999999,33.662222],"type":"Point"}
 }

--- a/data/102/541/685/102541685.geojson
+++ b/data/102/541/685/102541685.geojson
@@ -46,6 +46,10 @@
     "name:eng_x_preferred":[
         "Narita International Airport"
     ],
+    "name:eng_x_variant":[
+        "NRT",
+        "RJAA"
+    ],
     "name:epo_x_preferred":[
         "Internacia Flughaveno Narita"
     ],
@@ -189,7 +193,7 @@
         }
     ],
     "wof:id":102541685,
-    "wof:lastmodified":1566724947,
+    "wof:lastmodified":1631733561,
     "wof:name":"Narita International Airport",
     "wof:parent_id":102031933,
     "wof:placetype":"campus",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1963

This PR adds existing `iata:code and `icao:code` concordance values as English name variants. If these changes (and two other related PRs) look good, I'll apply them directly to each admin repo.