### PR TITLE
Update name postfixes

### DIFF
--- a/data/102/031/231/102031231.geojson
+++ b/data/102/031/231/102031231.geojson
@@ -44,6 +44,9 @@
     "name:eng_x_preferred":[
         "Yoshino"
     ],
+    "name:eng_x_variant":[
+        "Yoshino-ch\u014d"
+    ],
     "name:fas_x_preferred":[
         "\u06cc\u0648\u0634\u06cc\u0646\u0648"
     ],
@@ -164,8 +167,8 @@
         }
     ],
     "wof:id":102031231,
-    "wof:lastmodified":1690937583,
-    "wof:name":"Yoshino-ch\u014d",
+    "wof:lastmodified":1730094977,
+    "wof:name":"Yoshino",
     "wof:parent_id":1108742603,
     "wof:placetype":"locality",
     "wof:population":8829,

--- a/data/102/031/887/102031887.geojson
+++ b/data/102/031/887/102031887.geojson
@@ -44,6 +44,9 @@
     "name:eng_x_preferred":[
         "Masaki"
     ],
+    "name:eng_x_variant":[
+        "Masaki-ch\u014d"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0627\u0633\u0627\u06a9\u06cc"
     ],
@@ -123,8 +126,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672711,
-        1108742923
+        1108742923,
+        85672711
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -146,8 +149,8 @@
         }
     ],
     "wof:id":102031887,
-    "wof:lastmodified":1690937523,
-    "wof:name":"Masaki-ch\u014d",
+    "wof:lastmodified":1730094977,
+    "wof:name":"Masaki",
     "wof:parent_id":1108742923,
     "wof:placetype":"locality",
     "wof:population":30548,

--- a/data/102/031/917/102031917.geojson
+++ b/data/102/031/917/102031917.geojson
@@ -58,6 +58,9 @@
     "name:eng_x_preferred":[
         "Shirakawa"
     ],
+    "name:eng_x_variant":[
+        "Shirakawa-machi"
+    ],
     "name:est_x_preferred":[
         "Shirakawa"
     ],
@@ -218,8 +221,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672835,
-        890520803
+        890520803,
+        85672835
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -238,8 +241,8 @@
         }
     ],
     "wof:id":102031917,
-    "wof:lastmodified":1690937606,
-    "wof:name":"Shirakawa-machi",
+    "wof:lastmodified":1730094977,
+    "wof:name":"Shirakawa",
     "wof:parent_id":890520803,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jp",

--- a/data/102/031/925/102031925.geojson
+++ b/data/102/031/925/102031925.geojson
@@ -38,11 +38,12 @@
         "\u039f\u03bd\u03b1\u03b3\u03ba\u03ac\u03bf\u03c5\u03b1"
     ],
     "name:eng_x_preferred":[
-        "Onagawa-cho"
+        "Onagawa"
     ],
     "name:eng_x_variant":[
-        "Onagawa",
-        "Onagawa-chou"
+        "Onagawa-chou",
+        "Onagawa Ch\u014d",
+        "Onagawa-cho"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0648\u0646\u0627\u06af\u0627\u0648\u0627"
@@ -156,8 +157,8 @@
     "wof:lang":[
         "jpn"
     ],
-    "wof:lastmodified":1690937552,
-    "wof:name":"Onagawa Ch\u014d",
+    "wof:lastmodified":1730271551,
+    "wof:name":"Onagawa",
     "wof:parent_id":1108740045,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jp",

--- a/data/102/032/007/102032007.geojson
+++ b/data/102/032/007/102032007.geojson
@@ -46,6 +46,9 @@
     "name:eng_x_preferred":[
         "Misaki"
     ],
+    "name:eng_x_variant":[
+        "Misaki Ch\u014d"
+    ],
     "name:epo_x_preferred":[
         "Misaki"
     ],
@@ -129,8 +132,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672785,
-        890520511
+        890520511,
+        85672785
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -151,8 +154,8 @@
         }
     ],
     "wof:id":102032007,
-    "wof:lastmodified":1690937623,
-    "wof:name":"Misaki Ch\u014d",
+    "wof:lastmodified":1730271551,
+    "wof:name":"Misaki",
     "wof:parent_id":890520511,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jp",

--- a/data/110/873/985/1/1108739851.geojson
+++ b/data/110/873/985/1/1108739851.geojson
@@ -37,9 +37,11 @@
     "mz:is_current":1,
     "mz:min_zoom":6.0,
     "name:eng_x_preferred":[
+        "shikotan"
+    ],
+    "name:eng_x_variant":[
         "shikotan-mura"
     ],
-    "name:eng_x_variant":[],
     "name:fra_x_preferred":[
         "Shikotan"
     ],
@@ -60,7 +62,7 @@
     "wof:concordances_official":"meso:local_id",
     "wof:country":"JP",
     "wof:created":1479146207,
-    "wof:geomhash":"a4ad02ee2a6dd031dbd12e1840fe626f",
+    "wof:geomhash":"cc49c9ff06ef2561ff93c4013d08da77",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,8 +78,8 @@
         }
     ],
     "wof:id":1108739851,
-    "wof:lastmodified":1695886734,
-    "wof:name":"shikotan-mura",
+    "wof:lastmodified":1730094983,
+    "wof:name":"shikotan",
     "wof:parent_id":-1,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-jp",

--- a/data/110/873/985/1/1108739851.geojson
+++ b/data/110/873/985/1/1108739851.geojson
@@ -11,10 +11,13 @@
     "geom:longitude":146.740025,
     "iso:country":"JP",
     "label:eng_x_preferred_longname":[
-        "shikotan-mura"
+        "Shikotan"
     ],
     "label:eng_x_preferred_placetype":[
         "city"
+    ],
+    "label:eng_x_variant_longname":[
+        "Shikotan-mura"
     ],
     "lbl:latitude":43.784896,
     "lbl:longitude":146.714395,
@@ -37,10 +40,10 @@
     "mz:is_current":1,
     "mz:min_zoom":6.0,
     "name:eng_x_preferred":[
-        "shikotan"
+        "Shikotan"
     ],
     "name:eng_x_variant":[
-        "shikotan-mura"
+        "Shikotan-mura"
     ],
     "name:fra_x_preferred":[
         "Shikotan"
@@ -78,8 +81,8 @@
         }
     ],
     "wof:id":1108739851,
-    "wof:lastmodified":1730094983,
-    "wof:name":"shikotan",
+    "wof:lastmodified":1730096394,
+    "wof:name":"Shikotan",
     "wof:parent_id":-1,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-jp",

--- a/data/120/957/415/7/1209574157.geojson
+++ b/data/120/957/415/7/1209574157.geojson
@@ -30,6 +30,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kaneyaki"
+    ],
+    "name:eng_x_variant":[
+        "Kaneyaki-ni"
+    ],
     "name:jpn_x_preferred":[
         "\u91d1\u713c\u4e8c"
     ],
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":1209574157,
-    "wof:lastmodified":1566725741,
-    "wof:name":"Kaneyaki-ni",
+    "wof:lastmodified":1730271555,
+    "wof:name":"Kaneyaki",
     "wof:parent_id":85632429,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jp",

--- a/data/124/338/391/9/1243383919.geojson
+++ b/data/124/338/391/9/1243383919.geojson
@@ -31,6 +31,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Katsuno"
+    ],
+    "name:eng_x_variant":[
+        "Katsuno-ni"
+    ],
     "name:jpn_x_preferred":[
         "\u52dd\u91ce\u4e8c"
     ],
@@ -38,15 +44,15 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672697,
-        1108743053
+        1108743053,
+        85672697
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":10266450
     },
     "wof:country":"JP",
-    "wof:geomhash":"10f769b95d33b38148abd83e30b80c9a",
+    "wof:geomhash":"233fe0afaac16afc36b92d5bacfe2f4a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":1243383919,
-    "wof:lastmodified":1566726508,
-    "wof:name":"Katsuno-ni",
+    "wof:lastmodified":1730271560,
+    "wof:name":"Katsuno",
     "wof:parent_id":1108743053,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jp",
@@ -67,10 +73,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    130.70266999999998,
-    33.69439000000001,
-    130.70266999999998,
-    33.69439000000001
+    130.70267,
+    33.69439,
+    130.70267,
+    33.69439
 ],
-  "geometry": {"coordinates":[130.70266999999998,33.69439000000001],"type":"Point"}
+  "geometry": {"coordinates":[130.70267000000001,33.69439],"type":"Point"}
 }

--- a/data/125/947/989/7/1259479897.geojson
+++ b/data/125/947/989/7/1259479897.geojson
@@ -31,6 +31,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Sasao"
+    ],
+    "name:eng_x_variant":[
+        "Sasao-ni"
+    ],
     "name:jpn_x_preferred":[
         "\u7b39\u5c3e\u4e8c"
     ],
@@ -38,8 +44,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672697,
-        1108743059
+        1108743059,
+        85672697
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":1259479897,
-    "wof:lastmodified":1566726717,
-    "wof:name":"Sasao-ni",
+    "wof:lastmodified":1730271561,
+    "wof:name":"Sasao",
     "wof:parent_id":1108743059,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jp",

--- a/data/125/969/097/3/1259690973.geojson
+++ b/data/125/969/097/3/1259690973.geojson
@@ -30,6 +30,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Tonan Han Kinen Kanko"
+    ],
+    "name:eng_x_variant":[
+        "Tonan Han Kinen Kanko Mura"
+    ],
     "name:jpn_x_preferred":[
         "\u6597\u5357\u85e9\u8a18\u5ff5\u89b3\u5149\u6751"
     ],
@@ -44,15 +50,15 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672831,
-        890524885
+        890524885,
+        85672831
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":8395275
     },
     "wof:country":"JP",
-    "wof:geomhash":"38ee2d6b0c16f184282d93c0c72b726c",
+    "wof:geomhash":"9482384faca931bd2ec28fe4c53ce597",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -63,8 +69,8 @@
         }
     ],
     "wof:id":1259690973,
-    "wof:lastmodified":1566726748,
-    "wof:name":"Tonan Han Kinen Kanko Mura",
+    "wof:lastmodified":1730271561,
+    "wof:name":"Tonan Han Kinen Kanko",
     "wof:parent_id":890524885,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jp",
@@ -73,10 +79,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    141.36566000000005,
+    141.36566,
     40.78877,
-    141.36566000000005,
+    141.36566,
     40.78877
 ],
-  "geometry": {"coordinates":[141.36566000000005,40.78877],"type":"Point"}
+  "geometry": {"coordinates":[141.36565999999999,40.78877],"type":"Point"}
 }

--- a/data/125/973/459/7/1259734597.geojson
+++ b/data/125/973/459/7/1259734597.geojson
@@ -30,6 +30,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Showa"
+    ],
+    "name:eng_x_variant":[
+        "Showa-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u662d\u548c\u753a"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672817,
-        890524501
+        890524501,
+        85672817
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -56,8 +62,8 @@
         }
     ],
     "wof:id":1259734597,
-    "wof:lastmodified":1566726756,
-    "wof:name":"Showa-machi",
+    "wof:lastmodified":1730094993,
+    "wof:name":"Showa",
     "wof:parent_id":890524501,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jp",

--- a/data/125/978/007/1/1259780071.geojson
+++ b/data/125/978/007/1/1259780071.geojson
@@ -31,6 +31,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Gotoku"
+    ],
+    "name:eng_x_variant":[
+        "Gotoku-ni"
+    ],
     "name:jpn_x_preferred":[
         "\u5fa1\u5fb3\u4e8c"
     ],
@@ -38,8 +44,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672697,
-        1108743053
+        1108743053,
+        85672697
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":1259780071,
-    "wof:lastmodified":1566726715,
-    "wof:name":"Gotoku-ni",
+    "wof:lastmodified":1730271561,
+    "wof:name":"Gotoku",
     "wof:parent_id":1108743053,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jp",

--- a/data/125/996/563/5/1259965635.geojson
+++ b/data/125/996/563/5/1259965635.geojson
@@ -31,6 +31,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Toi"
+    ],
+    "name:eng_x_variant":[
+        "Toi-ni"
+    ],
     "name:jpn_x_preferred":[
         "\u571f\u5c45\u4e8c"
     ],
@@ -38,8 +44,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672697,
-        1108743059
+        1108743059,
+        85672697
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":1259965635,
-    "wof:lastmodified":1566726685,
-    "wof:name":"Toi-ni",
+    "wof:lastmodified":1730271561,
+    "wof:name":"Toi",
     "wof:parent_id":1108743059,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jp",

--- a/data/126/010/918/7/1260109187.geojson
+++ b/data/126/010/918/7/1260109187.geojson
@@ -30,6 +30,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Miyaharacho"
+    ],
+    "name:eng_x_variant":[
+        "Miyaharacho-do"
+    ],
     "name:jpn_x_preferred":[
         "\u5bae\u539f\u753a\u9053"
     ],
@@ -40,15 +46,15 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672795,
-        890524493
+        890524493,
+        85672795
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":9291585
     },
     "wof:country":"JP",
-    "wof:geomhash":"58986a889e4374816979832372c00b5a",
+    "wof:geomhash":"39ac2b43f486774357332357c20b81ab",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -59,8 +65,8 @@
         }
     ],
     "wof:id":1260109187,
-    "wof:lastmodified":1566725919,
-    "wof:name":"Miyaharacho-do",
+    "wof:lastmodified":1730271556,
+    "wof:name":"Miyaharacho",
     "wof:parent_id":890524493,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jp",
@@ -70,9 +76,9 @@
 },
   "bbox": [
     135.17352,
-    34.08600999999999,
+    34.08601,
     135.17352,
-    34.08600999999999
+    34.08601
 ],
-  "geometry": {"coordinates":[135.17352,34.08600999999999],"type":"Point"}
+  "geometry": {"coordinates":[135.17352,34.08601],"type":"Point"}
 }

--- a/data/131/009/139/7/1310091397.geojson
+++ b/data/131/009/139/7/1310091397.geojson
@@ -31,6 +31,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Haji"
+    ],
+    "name:eng_x_variant":[
+        "Haji-ni"
+    ],
     "name:jpn_x_preferred":[
         "\u571f\u5e2b\u4e8c"
     ],
@@ -38,8 +44,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672697,
-        1108743059
+        1108743059,
+        85672697
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":1310091397,
-    "wof:lastmodified":1566726055,
-    "wof:name":"Haji-ni",
+    "wof:lastmodified":1730271558,
+    "wof:name":"Haji",
     "wof:parent_id":1108743059,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jp",

--- a/data/131/024/739/9/1310247399.geojson
+++ b/data/131/024/739/9/1310247399.geojson
@@ -30,19 +30,25 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Shiobara"
+    ],
+    "name:eng_x_variant":[
+        "Shiobara-machi"
+    ],
     "src:geom":"geonames",
     "wof:belongsto":[
         102191569,
         85632429,
-        85672813,
-        890520259
+        890520259,
+        85672813
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":1852026
     },
     "wof:country":"JP",
-    "wof:geomhash":"7e23508d2f0bca61b8f68a197961593e",
+    "wof:geomhash":"53be6b3b058b167e03d715cc4cc2be0f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -53,8 +59,8 @@
         }
     ],
     "wof:id":1310247399,
-    "wof:lastmodified":1566726020,
-    "wof:name":"Shiobara-machi",
+    "wof:lastmodified":1730094983,
+    "wof:name":"Shiobara",
     "wof:parent_id":890520259,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jp",
@@ -63,10 +69,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    139.83333000000002,
+    139.83333,
     36.96667,
-    139.83333000000002,
+    139.83333,
     36.96667
 ],
-  "geometry": {"coordinates":[139.83333000000002,36.96667],"type":"Point"}
+  "geometry": {"coordinates":[139.83332999999999,36.96667],"type":"Point"}
 }

--- a/data/132/668/409/7/1326684097.geojson
+++ b/data/132/668/409/7/1326684097.geojson
@@ -30,6 +30,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Huis-ten-bosch"
+    ],
+    "name:eng_x_variant":[
+        "Huis-ten-bosch-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u30cf\u30a6\u30b9\u30c6\u30f3\u30dc\u30b9\u753a"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672857,
-        1108743133
+        1108743133,
+        85672857
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -56,8 +62,8 @@
         }
     ],
     "wof:id":1326684097,
-    "wof:lastmodified":1566724807,
-    "wof:name":"Huis-ten-bosch-machi",
+    "wof:lastmodified":1730094976,
+    "wof:name":"Huis-ten-bosch",
     "wof:parent_id":1108743133,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jp",

--- a/data/132/746/162/1/1327461621.geojson
+++ b/data/132/746/162/1/1327461621.geojson
@@ -30,6 +30,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yamakawacho"
+    ],
+    "name:eng_x_variant":[
+        "Yamakawacho-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5c71\u5ddd\u753a\u753a"
     ],
@@ -42,8 +48,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672729,
-        890524145
+        890524145,
+        85672729
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":1327461621,
-    "wof:lastmodified":1566724831,
-    "wof:name":"Yamakawacho-machi",
+    "wof:lastmodified":1730094977,
+    "wof:name":"Yamakawacho",
     "wof:parent_id":890524145,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jp",

--- a/data/134/397/834/9/1343978349.geojson
+++ b/data/134/397/834/9/1343978349.geojson
@@ -31,6 +31,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yoshikuma"
+    ],
+    "name:eng_x_variant":[
+        "Yoshikuma-ni"
+    ],
     "name:jpn_x_preferred":[
         "\u5409\u9688\u4e8c"
     ],
@@ -38,8 +44,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672697,
-        1108743059
+        1108743059,
+        85672697
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":1343978349,
-    "wof:lastmodified":1566724974,
-    "wof:name":"Yoshikuma-ni",
+    "wof:lastmodified":1730271552,
+    "wof:name":"Yoshikuma",
     "wof:parent_id":1108743059,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jp",

--- a/data/890/519/305/890519305.geojson
+++ b/data/890/519/305/890519305.geojson
@@ -25,6 +25,9 @@
     "name:eng_x_preferred":[
         "Kozakai"
     ],
+    "name:eng_x_variant":[
+        "Kozakai-ch\u014d"
+    ],
     "name:fas_x_preferred":[
         "\u06a9\u0648\u0632\u0627\u06a9\u0627\u06cc"
     ],
@@ -63,8 +66,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672731,
-        1108742251
+        1108742251,
+        85672731
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -86,8 +89,8 @@
         }
     ],
     "wof:id":890519305,
-    "wof:lastmodified":1690937838,
-    "wof:name":"Kozakai-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Kozakai",
     "wof:parent_id":1108742251,
     "wof:placetype":"locality",
     "wof:population":22064,

--- a/data/890/519/567/890519567.geojson
+++ b/data/890/519/567/890519567.geojson
@@ -40,6 +40,9 @@
     "name:eng_x_preferred":[
         "Taketoyo"
     ],
+    "name:eng_x_variant":[
+        "Taketoyo-ch\u014d"
+    ],
     "name:fas_x_preferred":[
         "\u062a\u0627\u06a9\u0647\u200c\u062a\u0648\u06cc\u0648"
     ],
@@ -109,8 +112,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672731,
-        1108742305
+        1108742305,
+        85672731
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -132,8 +135,8 @@
         }
     ],
     "wof:id":890519567,
-    "wof:lastmodified":1690937802,
-    "wof:name":"Taketoyo-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Taketoyo",
     "wof:parent_id":1108742305,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/569/890519569.geojson
+++ b/data/890/519/569/890519569.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Agui"
+    ],
+    "name:eng_x_variant":[
+        "Agui-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u963f\u4e45\u6bd4\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672731,
-        1108742295
+        1108742295,
+        85672731
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890519569,
-    "wof:lastmodified":1566726342,
-    "wof:name":"Agui-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Agui",
     "wof:parent_id":1108742295,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/573/890519573.geojson
+++ b/data/890/519/573/890519573.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Isshiki"
+    ],
+    "name:eng_x_variant":[
+        "Isshiki-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u4e00\u8272\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672731,
-        890520407
+        890520407,
+        85672731
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890519573,
-    "wof:lastmodified":1566726349,
-    "wof:name":"Isshiki-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Isshiki",
     "wof:parent_id":890520407,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/579/890519579.geojson
+++ b/data/890/519/579/890519579.geojson
@@ -43,6 +43,9 @@
     "name:eng_x_preferred":[
         "Fujisaki"
     ],
+    "name:eng_x_variant":[
+        "Fujisaki Machi"
+    ],
     "name:fas_x_preferred":[
         "\u0641\u0648\u062c\u06cc\u0633\u0627\u06a9\u06cc"
     ],
@@ -125,8 +128,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672831,
-        1108739885
+        1108739885,
+        85672831
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -148,8 +151,8 @@
         }
     ],
     "wof:id":890519579,
-    "wof:lastmodified":1690937859,
-    "wof:name":"Fujisaki Machi",
+    "wof:lastmodified":1730271559,
+    "wof:name":"Fujisaki",
     "wof:parent_id":1108739885,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/617/890519617.geojson
+++ b/data/890/519/617/890519617.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kiyotake"
+    ],
+    "name:eng_x_variant":[
+        "Kiyotake-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u6e05\u6b66\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672707,
-        1108743259
+        1108743259,
+        85672707
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890519617,
-    "wof:lastmodified":1566726345,
-    "wof:name":"Kiyotake-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Kiyotake",
     "wof:parent_id":1108743259,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/637/890519637.geojson
+++ b/data/890/519/637/890519637.geojson
@@ -34,6 +34,9 @@
     "name:eng_x_preferred":[
         "Minamimaki"
     ],
+    "name:eng_x_variant":[
+        "Minamimaki-mura"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u06cc\u0646\u0627\u0645\u06cc\u200c\u0645\u0627\u06a9\u06cc"
     ],
@@ -97,8 +100,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672749,
-        1108741999
+        1108741999,
+        85672749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -120,8 +123,8 @@
         }
     ],
     "wof:id":890519637,
-    "wof:lastmodified":1690937847,
-    "wof:name":"Minamimaki-mura",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Minamimaki",
     "wof:parent_id":1108741999,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/639/890519639.geojson
+++ b/data/890/519/639/890519639.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nishihara"
+    ],
+    "name:eng_x_variant":[
+        "Nishihara-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u897f\u539f\u6751"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672703,
-        1108743189
+        1108743189,
+        85672703
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890519639,
-    "wof:lastmodified":1566726354,
-    "wof:name":"Nishihara-mura",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Nishihara",
     "wof:parent_id":1108743189,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/641/890519641.geojson
+++ b/data/890/519/641/890519641.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kunitomi"
+    ],
+    "name:eng_x_variant":[
+        "Kunitomi-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u56fd\u5bcc\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672707,
-        1108743271
+        1108743271,
+        85672707
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890519641,
-    "wof:lastmodified":1566726353,
-    "wof:name":"Kunitomi-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Kunitomi",
     "wof:parent_id":1108743271,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/645/890519645.geojson
+++ b/data/890/519/645/890519645.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Shintomi"
+    ],
+    "name:eng_x_variant":[
+        "Shintomi-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u65b0\u5bcc\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672707,
-        1108743279
+        1108743279,
+        85672707
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890519645,
-    "wof:lastmodified":1566726345,
-    "wof:name":"Shintomi-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Shintomi",
     "wof:parent_id":1108743279,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/647/890519647.geojson
+++ b/data/890/519/647/890519647.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Shingamigot\u014d"
+    ],
+    "name:eng_x_variant":[
+        "Shingamigot\u014d-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u65b0\u4e0a\u4e94\u5cf6\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672857,
-        1108743153
+        1108743153,
+        85672857
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890519647,
-    "wof:lastmodified":1566726352,
-    "wof:name":"Shingamigot\u014d-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Shingamigot\u014d",
     "wof:parent_id":1108743153,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/663/890519663.geojson
+++ b/data/890/519/663/890519663.geojson
@@ -22,6 +22,9 @@
     "name:eng_x_preferred":[
         "Ikata"
     ],
+    "name:eng_x_variant":[
+        "Ikata-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u4f0a\u65b9\u753a"
     ],
@@ -33,8 +36,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672711,
-        1108742929
+        1108742929,
+        85672711
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +57,8 @@
         }
     ],
     "wof:id":890519663,
-    "wof:lastmodified":1566726353,
-    "wof:name":"Ikata-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Ikata",
     "wof:parent_id":1108742929,
     "wof:placetype":"localadmin",
     "wof:population":12500,

--- a/data/890/519/689/890519689.geojson
+++ b/data/890/519/689/890519689.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Shiraoi"
+    ],
+    "name:eng_x_variant":[
+        "Shiraoi-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u767d\u8001\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739761
+        1108739761,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890519689,
-    "wof:lastmodified":1566726345,
-    "wof:name":"Shiraoi-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Shiraoi",
     "wof:parent_id":1108739761,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/691/890519691.geojson
+++ b/data/890/519/691/890519691.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Hayama"
+    ],
+    "name:eng_x_variant":[
+        "Hayama-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u8449\u5c71\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672805,
-        1108741795
+        1108741795,
+        85672805
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890519691,
-    "wof:lastmodified":1566726354,
-    "wof:name":"Hayama-machi",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Hayama",
     "wof:parent_id":1108741795,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/737/890519737.geojson
+++ b/data/890/519/737/890519737.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kawauchi"
+    ],
+    "name:eng_x_variant":[
+        "Kawauchi-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u5ddd\u5185\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672835,
-        1108740257
+        1108740257,
+        85672835
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890519737,
-    "wof:lastmodified":1566726343,
-    "wof:name":"Kawauchi-mura",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Kawauchi",
     "wof:parent_id":1108740257,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/739/890519739.geojson
+++ b/data/890/519/739/890519739.geojson
@@ -43,6 +43,9 @@
     "name:eng_x_preferred":[
         "Minamiaizu"
     ],
+    "name:eng_x_variant":[
+        "Minamiaizu-machi"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u06cc\u0646\u0627\u0645\u06cc\u200c\u0622\u06cc\u0632\u0648"
     ],
@@ -109,8 +112,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672835,
-        1108740189
+        1108740189,
+        85672835
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -132,8 +135,8 @@
         }
     ],
     "wof:id":890519739,
-    "wof:lastmodified":1690937804,
-    "wof:name":"Minamiaizu-machi",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Minamiaizu",
     "wof:parent_id":1108740189,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/741/890519741.geojson
+++ b/data/890/519/741/890519741.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Shinchi"
+    ],
+    "name:eng_x_variant":[
+        "Shinchi-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u65b0\u5730\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672835,
-        1108740269
+        1108740269,
+        85672835
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890519741,
-    "wof:lastmodified":1566726349,
-    "wof:name":"Shinchi-machi",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Shinchi",
     "wof:parent_id":1108740269,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/745/890519745.geojson
+++ b/data/890/519/745/890519745.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yamanobe"
+    ],
+    "name:eng_x_variant":[
+        "Yamanobe-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5c71\u8fba\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672853,
-        1108740107
+        1108740107,
+        85672853
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890519745,
-    "wof:lastmodified":1566726356,
-    "wof:name":"Yamanobe-machi",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Yamanobe",
     "wof:parent_id":1108740107,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/783/890519783.geojson
+++ b/data/890/519/783/890519783.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Tateshina"
+    ],
+    "name:eng_x_variant":[
+        "Tateshina-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u7acb\u79d1\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672749,
-        1108742011
+        1108742011,
+        85672749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890519783,
-    "wof:lastmodified":1566726349,
-    "wof:name":"Tateshina-machi",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Tateshina",
     "wof:parent_id":1108742011,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/785/890519785.geojson
+++ b/data/890/519/785/890519785.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Chizu"
+    ],
+    "name:eng_x_variant":[
+        "Chizu-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u667a\u982d\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672685,
-        1108742687
+        1108742687,
+        85672685
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890519785,
-    "wof:lastmodified":1566726348,
-    "wof:name":"Chizu-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Chizu",
     "wof:parent_id":1108742687,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/789/890519789.geojson
+++ b/data/890/519/789/890519789.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kawamoto"
+    ],
+    "name:eng_x_variant":[
+        "Kawamoto-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5ddd\u672c\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672679,
-        1108742725
+        1108742725,
+        85672679
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890519789,
-    "wof:lastmodified":1566726356,
-    "wof:name":"Kawamoto-machi",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Kawamoto",
     "wof:parent_id":1108742725,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/791/890519791.geojson
+++ b/data/890/519/791/890519791.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kamijima"
+    ],
+    "name:eng_x_variant":[
+        "Kamijima-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u4e0a\u5cf6\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672711,
         1108742919,
+        85672711,
         85681261
     ],
     "wof:breaches":[],
@@ -65,8 +71,8 @@
         }
     ],
     "wof:id":890519791,
-    "wof:lastmodified":1566726343,
-    "wof:name":"Kamijima-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Kamijima",
     "wof:parent_id":1108742919,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/793/890519793.geojson
+++ b/data/890/519/793/890519793.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kanmaki"
+    ],
+    "name:eng_x_variant":[
+        "Kanmaki-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u4e0a\u7267\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672779,
-        1108742595
+        1108742595,
+        85672779
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890519793,
-    "wof:lastmodified":1566726350,
-    "wof:name":"Kanmaki-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Kanmaki",
     "wof:parent_id":1108742595,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/795/890519795.geojson
+++ b/data/890/519/795/890519795.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Misato"
+    ],
+    "name:eng_x_variant":[
+        "Misato-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u7f8e\u91cc\u753a"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672703,
-        1108743163
+        1108743163,
+        85672703
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890519795,
-    "wof:lastmodified":1566726351,
-    "wof:name":"Misato-machi",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Misato",
     "wof:parent_id":1108743163,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/797/890519797.geojson
+++ b/data/890/519/797/890519797.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nagasu"
+    ],
+    "name:eng_x_variant":[
+        "Nagasu-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u9577\u6d32\u753a"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672703,
-        1108743171
+        1108743171,
+        85672703
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890519797,
-    "wof:lastmodified":1566726342,
-    "wof:name":"Nagasu-machi",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Nagasu",
     "wof:parent_id":1108743171,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/799/890519799.geojson
+++ b/data/890/519/799/890519799.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "\u014czu"
+    ],
+    "name:eng_x_variant":[
+        "\u014czu-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5927\u6d25\u753a"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672703,
-        1108743175
+        1108743175,
+        85672703
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890519799,
-    "wof:lastmodified":1566726342,
-    "wof:name":"\u014czu-machi",
+    "wof:lastmodified":1730094985,
+    "wof:name":"\u014czu",
     "wof:parent_id":1108743175,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/801/890519801.geojson
+++ b/data/890/519/801/890519801.geojson
@@ -40,6 +40,9 @@
     "name:eng_x_preferred":[
         "Minamioguni"
     ],
+    "name:eng_x_variant":[
+        "Minamioguni-machi"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u06cc\u0646\u0627\u0645\u06cc\u200c\u0627\u0648\u06af\u0648\u0646\u06cc"
     ],
@@ -104,8 +107,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672703,
-        1108743179
+        1108743179,
+        85672703
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -127,8 +130,8 @@
         }
     ],
     "wof:id":890519801,
-    "wof:lastmodified":1690937851,
-    "wof:name":"Minamioguni-machi",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Minamioguni",
     "wof:parent_id":1108743179,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/807/890519807.geojson
+++ b/data/890/519/807/890519807.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Tobishima"
+    ],
+    "name:eng_x_variant":[
+        "Tobishima-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u98db\u5cf6\u6751"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672731,
-        1108742293
+        1108742293,
+        85672731
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890519807,
-    "wof:lastmodified":1566726353,
-    "wof:name":"Tobishima-mura",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Tobishima",
     "wof:parent_id":1108742293,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/809/890519809.geojson
+++ b/data/890/519/809/890519809.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "T\u014din"
+    ],
+    "name:eng_x_variant":[
+        "T\u014din-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u6771\u54e1\u753a"
     ],
@@ -34,8 +40,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672745,
-        1108742329
+        1108742329,
+        85672745
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,8 +61,8 @@
         }
     ],
     "wof:id":890519809,
-    "wof:lastmodified":1566726353,
-    "wof:name":"T\u014din-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"T\u014din",
     "wof:parent_id":1108742329,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/909/890519909.geojson
+++ b/data/890/519/909/890519909.geojson
@@ -22,6 +22,9 @@
     "name:eng_x_preferred":[
         "Tobe"
     ],
+    "name:eng_x_variant":[
+        "Tobe-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u7825\u90e8\u753a"
     ],
@@ -33,8 +36,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672711,
-        1108742925
+        1108742925,
+        85672711
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +57,8 @@
         }
     ],
     "wof:id":890519909,
-    "wof:lastmodified":1566726342,
-    "wof:name":"Tobe-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Tobe",
     "wof:parent_id":1108742925,
     "wof:placetype":"localadmin",
     "wof:population":21382,

--- a/data/890/519/911/890519911.geojson
+++ b/data/890/519/911/890519911.geojson
@@ -46,6 +46,9 @@
     "name:eng_x_preferred":[
         "Ichinomiya"
     ],
+    "name:eng_x_variant":[
+        "Ichinomiya-machi"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u06cc\u0686\u06cc\u0646\u0648\u0645\u06cc\u0627"
     ],
@@ -125,8 +128,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672797,
-        1108741659
+        1108741659,
+        85672797
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -148,8 +151,8 @@
         }
     ],
     "wof:id":890519911,
-    "wof:lastmodified":1690937854,
-    "wof:name":"Ichinomiya-machi",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Ichinomiya",
     "wof:parent_id":1108741659,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/935/890519935.geojson
+++ b/data/890/519/935/890519935.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "G\u014ddo"
+    ],
+    "name:eng_x_variant":[
+        "G\u014ddo-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u3054\u3046\u3069\u3061\u3087\u3046"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672735,
-        1108742149
+        1108742149,
+        85672735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890519935,
-    "wof:lastmodified":1566726350,
-    "wof:name":"G\u014ddo-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"G\u014ddo",
     "wof:parent_id":1108742149,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/975/890519975.geojson
+++ b/data/890/519/975/890519975.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nakafurano"
+    ],
+    "name:eng_x_variant":[
+        "Nakafurano-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u4e2d\u5bcc\u826f\u91ce\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739663
+        1108739663,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890519975,
-    "wof:lastmodified":1566726357,
-    "wof:name":"Nakafurano-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Nakafurano",
     "wof:parent_id":1108739663,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/977/890519977.geojson
+++ b/data/890/519/977/890519977.geojson
@@ -20,6 +20,9 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "name:eng_x_preferred":[
+        "Sugito"
+    ],
+    "name:eng_x_variant":[
         "Sugito-machi"
     ],
     "name:jpn_x_preferred":[
@@ -40,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672807,
-        1108740527
+        1108740527,
+        85672807
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -61,8 +64,8 @@
         }
     ],
     "wof:id":890519977,
-    "wof:lastmodified":1566726348,
-    "wof:name":"Sugito-machi",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Sugito",
     "wof:parent_id":1108740527,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/519/979/890519979.geojson
+++ b/data/890/519/979/890519979.geojson
@@ -22,6 +22,9 @@
     "name:eng_x_preferred":[
         "Fujiwara"
     ],
+    "name:eng_x_variant":[
+        "Fujiwara-ch\u014d"
+    ],
     "name:fra_x_preferred":[
         "Fujiwara"
     ],
@@ -46,8 +49,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672745,
-        890524843
+        890524843,
+        85672745
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -69,8 +72,8 @@
         }
     ],
     "wof:id":890519979,
-    "wof:lastmodified":1690937824,
-    "wof:name":"Fujiwara-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Fujiwara",
     "wof:parent_id":890524843,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/013/890520013.geojson
+++ b/data/890/520/013/890520013.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Okinoshima"
+    ],
+    "name:eng_x_variant":[
+        "Okinoshima-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u96a0\u5c90\u306e\u5cf6\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672679,
-        1108742743
+        1108742743,
+        85672679
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520013,
-    "wof:lastmodified":1566726377,
-    "wof:name":"Okinoshima-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Okinoshima",
     "wof:parent_id":1108742743,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/015/890520015.geojson
+++ b/data/890/520/015/890520015.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Oguni"
+    ],
+    "name:eng_x_variant":[
+        "Oguni-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5c0f\u56fd\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672853,
-        1108740139
+        1108740139,
+        85672853
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520015,
-    "wof:lastmodified":1566726376,
-    "wof:name":"Oguni-machi",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Oguni",
     "wof:parent_id":1108740139,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/023/890520023.geojson
+++ b/data/890/520/023/890520023.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Hiezu"
+    ],
+    "name:eng_x_variant":[
+        "Hiezu-son"
+    ],
     "name:jpn_x_preferred":[
         "\u65e5\u5409\u6d25\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672685,
-        1108742701
+        1108742701,
+        85672685
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520023,
-    "wof:lastmodified":1566726376,
-    "wof:name":"Hiezu-son",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Hiezu",
     "wof:parent_id":1108742701,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/071/890520071.geojson
+++ b/data/890/520/071/890520071.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Haebaru"
+    ],
+    "name:eng_x_variant":[
+        "Haebaru-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5357\u98a8\u539f\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672867,
-        1108743421
+        1108743421,
+        85672867
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520071,
-    "wof:lastmodified":1566726378,
-    "wof:name":"Haebaru-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Haebaru",
     "wof:parent_id":1108743421,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/077/890520077.geojson
+++ b/data/890/520/077/890520077.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Hara"
+    ],
+    "name:eng_x_variant":[
+        "Hara-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u539f\u6751"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672749,
-        1108742023
+        1108742023,
+        85672749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520077,
-    "wof:lastmodified":1566726377,
-    "wof:name":"Hara-mura",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Hara",
     "wof:parent_id":1108742023,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/091/890520091.geojson
+++ b/data/890/520/091/890520091.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Naganuma"
+    ],
+    "name:eng_x_variant":[
+        "Naganuma-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u9577\u6cbc\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739621
+        1108739621,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520091,
-    "wof:lastmodified":1566726378,
-    "wof:name":"Naganuma-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Naganuma",
     "wof:parent_id":1108739621,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/115/890520115.geojson
+++ b/data/890/520/115/890520115.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Toyono"
+    ],
+    "name:eng_x_variant":[
+        "Toyono-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u8c4a\u80fd\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672785,
-        1108742483
+        1108742483,
+        85672785
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520115,
-    "wof:lastmodified":1566726388,
-    "wof:name":"Toyono-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Toyono",
     "wof:parent_id":1108742483,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/117/890520117.geojson
+++ b/data/890/520/117/890520117.geojson
@@ -20,6 +20,10 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "name:eng_x_preferred":[
+        "Tonosh\u014d"
+    ],
+    "name:eng_x_variant":[
+        "Tonosh\u014d-ch\u014d",
         "Tonosho-cho"
     ],
     "name:jpn_x_preferred":[
@@ -39,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672715,
-        1108742889
+        1108742889,
+        85672715
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -60,8 +64,8 @@
         }
     ],
     "wof:id":890520117,
-    "wof:lastmodified":1566726382,
-    "wof:name":"Tonosh\u014d-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Tonosh\u014d",
     "wof:parent_id":1108742889,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/119/890520119.geojson
+++ b/data/890/520/119/890520119.geojson
@@ -20,6 +20,10 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "name:eng_x_preferred":[
+        "Seika"
+    ],
+    "name:eng_x_variant":[
+        "Seika-ch\u014d",
         "Seika-cho"
     ],
     "name:jpn_x_preferred":[
@@ -40,8 +44,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672777,
-        1108742429
+        1108742429,
+        85672777
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -61,8 +65,8 @@
         }
     ],
     "wof:id":890520119,
-    "wof:lastmodified":1566726382,
-    "wof:name":"Seika-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Seika",
     "wof:parent_id":1108742429,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/121/890520121.geojson
+++ b/data/890/520/121/890520121.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yosano"
+    ],
+    "name:eng_x_variant":[
+        "Yosano-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u4e0e\u8b1d\u91ce\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672777,
-        1108742437
+        1108742437,
+        85672777
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520121,
-    "wof:lastmodified":1566726382,
-    "wof:name":"Yosano-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Yosano",
     "wof:parent_id":1108742437,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/123/890520123.geojson
+++ b/data/890/520/123/890520123.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nagiso"
+    ],
+    "name:eng_x_variant":[
+        "Nagiso-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5357\u6728\u66fd\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672749,
-        1108742071
+        1108742071,
+        85672749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520123,
-    "wof:lastmodified":1566726389,
-    "wof:name":"Nagiso-machi",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Nagiso",
     "wof:parent_id":1108742071,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/125/890520125.geojson
+++ b/data/890/520/125/890520125.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kiso"
+    ],
+    "name:eng_x_variant":[
+        "Kiso-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u6728\u7956\u6751"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672749,
-        1108742073
+        1108742073,
+        85672749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520125,
-    "wof:lastmodified":1566726390,
-    "wof:name":"Kiso-mura",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Kiso",
     "wof:parent_id":1108742073,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/127/890520127.geojson
+++ b/data/890/520/127/890520127.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kiso"
+    ],
+    "name:eng_x_variant":[
+        "Kiso-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u6728\u66fd\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672749,
-        1108742079
+        1108742079,
+        85672749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520127,
-    "wof:lastmodified":1566726381,
-    "wof:name":"Kiso-machi",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Kiso",
     "wof:parent_id":1108742079,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/143/890520143.geojson
+++ b/data/890/520/143/890520143.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Togitsu"
+    ],
+    "name:eng_x_variant":[
+        "Togitsu-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u6642\u6d25\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672857,
-        1108743139
+        1108743139,
+        85672857
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520143,
-    "wof:lastmodified":1566726382,
-    "wof:name":"Togitsu-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Togitsu",
     "wof:parent_id":1108743139,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/157/890520157.geojson
+++ b/data/890/520/157/890520157.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kawatana"
+    ],
+    "name:eng_x_variant":[
+        "Kawatana-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5ddd\u68da\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672857,
-        1108743143
+        1108743143,
+        85672857
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520157,
-    "wof:lastmodified":1566726375,
-    "wof:name":"Kawatana-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Kawatana",
     "wof:parent_id":1108743143,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/167/890520167.geojson
+++ b/data/890/520/167/890520167.geojson
@@ -40,6 +40,9 @@
     "name:eng_x_preferred":[
         "Kamig\u014dri"
     ],
+    "name:eng_x_variant":[
+        "Kamig\u014dri-ch\u014d"
+    ],
     "name:fas_x_preferred":[
         "\u06a9\u0627\u0645\u06cc\u06af\u0648\u0631\u06cc"
     ],
@@ -106,8 +109,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672769,
-        1108742547
+        1108742547,
+        85672769
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -129,8 +132,8 @@
         }
     ],
     "wof:id":890520167,
-    "wof:lastmodified":1690937868,
-    "wof:name":"Kamig\u014dri-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Kamig\u014dri",
     "wof:parent_id":1108742547,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/169/890520169.geojson
+++ b/data/890/520/169/890520169.geojson
@@ -40,6 +40,9 @@
     "name:eng_x_preferred":[
         "Kamikawa"
     ],
+    "name:eng_x_variant":[
+        "Kamikawa-ch\u014d"
+    ],
     "name:fas_x_preferred":[
         "\u06a9\u0627\u0645\u06cc\u06a9\u0627\u0648\u0627"
     ],
@@ -100,8 +103,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672769,
-        1108742543
+        1108742543,
+        85672769
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -123,8 +126,8 @@
         }
     ],
     "wof:id":890520169,
-    "wof:lastmodified":1690937869,
-    "wof:name":"Kamikawa-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Kamikawa",
     "wof:parent_id":1108742543,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/171/890520171.geojson
+++ b/data/890/520/171/890520171.geojson
@@ -40,6 +40,9 @@
     "name:eng_x_preferred":[
         "Fukusaki"
     ],
+    "name:eng_x_variant":[
+        "Fukusaki-ch\u014d"
+    ],
     "name:fas_x_preferred":[
         "\u0641\u0648\u06a9\u0648\u0633\u0627\u06a9\u06cc"
     ],
@@ -109,8 +112,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672769,
-        1108742541
+        1108742541,
+        85672769
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -132,8 +135,8 @@
         }
     ],
     "wof:id":890520171,
-    "wof:lastmodified":1690937914,
-    "wof:name":"Fukusaki-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Fukusaki",
     "wof:parent_id":1108742541,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/173/890520173.geojson
+++ b/data/890/520/173/890520173.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Inagawa"
+    ],
+    "name:eng_x_variant":[
+        "Inagawa-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u732a\u540d\u5ddd\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672769,
-        1108742529
+        1108742529,
+        85672769
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520173,
-    "wof:lastmodified":1566726381,
-    "wof:name":"Inagawa-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Inagawa",
     "wof:parent_id":1108742529,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/199/890520199.geojson
+++ b/data/890/520/199/890520199.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nakagusuku"
+    ],
+    "name:eng_x_variant":[
+        "Nakagusuku-son"
+    ],
     "name:jpn_x_preferred":[
         "\u4e2d\u57ce\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672867,
-        1108743413
+        1108743413,
+        85672867
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520199,
-    "wof:lastmodified":1566726384,
-    "wof:name":"Nakagusuku-son",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Nakagusuku",
     "wof:parent_id":1108743413,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/209/890520209.geojson
+++ b/data/890/520/209/890520209.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kawasaki"
+    ],
+    "name:eng_x_variant":[
+        "Kawasaki-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5ddd\u5d0e\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672843,
-        1108741049
+        1108741049,
+        85672843
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520209,
-    "wof:lastmodified":1566726386,
-    "wof:name":"Kawasaki-machi",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Kawasaki",
     "wof:parent_id":1108741049,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/223/890520223.geojson
+++ b/data/890/520/223/890520223.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yoshika"
+    ],
+    "name:eng_x_variant":[
+        "Yoshika-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5409\u8cc0\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672679,
-        1108742735
+        1108742735,
+        85672679
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520223,
-    "wof:lastmodified":1566726385,
-    "wof:name":"Yoshika-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Yoshika",
     "wof:parent_id":1108742735,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/227/890520227.geojson
+++ b/data/890/520/227/890520227.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nakijin"
+    ],
+    "name:eng_x_variant":[
+        "Nakijin-son"
+    ],
     "name:jpn_x_preferred":[
         "\u4eca\u5e30\u4ec1\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672867,
-        1108743391
+        1108743391,
+        85672867
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520227,
-    "wof:lastmodified":1566726376,
-    "wof:name":"Nakijin-son",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Nakijin",
     "wof:parent_id":1108743391,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/235/890520235.geojson
+++ b/data/890/520/235/890520235.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Heguri"
+    ],
+    "name:eng_x_variant":[
+        "Heguri-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5e73\u7fa4\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672779,
-        1108742569
+        1108742569,
+        85672779
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520235,
-    "wof:lastmodified":1566726379,
-    "wof:name":"Heguri-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Heguri",
     "wof:parent_id":1108742569,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/267/890520267.geojson
+++ b/data/890/520/267/890520267.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nagi"
+    ],
+    "name:eng_x_variant":[
+        "Nagi-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5948\u7fa9\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672675,
-        1108742775
+        1108742775,
+        85672675
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520267,
-    "wof:lastmodified":1566726379,
-    "wof:name":"Nagi-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Nagi",
     "wof:parent_id":1108742775,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/283/890520283.geojson
+++ b/data/890/520/283/890520283.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Hidaka"
+    ],
+    "name:eng_x_variant":[
+        "Hidaka-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u65e5\u9ad8\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672795,
-        1108742651
+        1108742651,
+        85672795
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520283,
-    "wof:lastmodified":1566726384,
-    "wof:name":"Hidaka-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Hidaka",
     "wof:parent_id":1108742651,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/285/890520285.geojson
+++ b/data/890/520/285/890520285.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Ogawa"
+    ],
+    "name:eng_x_variant":[
+        "Ogawa-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u5c0f\u5ddd\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672749,
-        1108742117
+        1108742117,
+        85672749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520285,
-    "wof:lastmodified":1566726386,
-    "wof:name":"Ogawa-mura",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Ogawa",
     "wof:parent_id":1108742117,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/355/890520355.geojson
+++ b/data/890/520/355/890520355.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Shinonsen"
+    ],
+    "name:eng_x_variant":[
+        "Shinonsen-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u65b0\u6e29\u6cc9\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672769,
-        1108742555
+        1108742555,
+        85672769
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520355,
-    "wof:lastmodified":1566726376,
-    "wof:name":"Shinonsen-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Shinonsen",
     "wof:parent_id":1108742555,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/371/890520371.geojson
+++ b/data/890/520/371/890520371.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Sh\u014dwa"
+    ],
+    "name:eng_x_variant":[
+        "Sh\u014dwa-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u662d\u548c\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672821,
-        1108741955
+        1108741955,
+        85672821
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520371,
-    "wof:lastmodified":1566726382,
-    "wof:name":"Sh\u014dwa-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Sh\u014dwa",
     "wof:parent_id":1108741955,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/375/890520375.geojson
+++ b/data/890/520/375/890520375.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Takayama"
+    ],
+    "name:eng_x_variant":[
+        "Takayama-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u9ad8\u5c71\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672749,
-        1108742107
+        1108742107,
+        85672749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520375,
-    "wof:lastmodified":1566726390,
-    "wof:name":"Takayama-mura",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Takayama",
     "wof:parent_id":1108742107,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/377/890520377.geojson
+++ b/data/890/520/377/890520377.geojson
@@ -34,6 +34,9 @@
     "name:eng_x_preferred":[
         "Kijimadaira"
     ],
+    "name:eng_x_variant":[
+        "Kijimadaira-mura"
+    ],
     "name:fas_x_preferred":[
         "\u06a9\u06cc\u062c\u06cc\u0645\u0627\u062f\u0627\u06cc\u0631\u0627"
     ],
@@ -97,8 +100,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672749,
-        1108742111
+        1108742111,
+        85672749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -120,8 +123,8 @@
         }
     ],
     "wof:id":890520377,
-    "wof:lastmodified":1690937884,
-    "wof:name":"Kijimadaira-mura",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Kijimadaira",
     "wof:parent_id":1108742111,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/395/890520395.geojson
+++ b/data/890/520/395/890520395.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Miyoshi"
+    ],
+    "name:eng_x_variant":[
+        "Miyoshi-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u4e09\u82b3\u753a"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672807,
-        1108740479
+        1108740479,
+        85672807
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890520395,
-    "wof:lastmodified":1566726383,
-    "wof:name":"Miyoshi-machi",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Miyoshi",
     "wof:parent_id":1108740479,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/405/890520405.geojson
+++ b/data/890/520/405/890520405.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yorii"
+    ],
+    "name:eng_x_variant":[
+        "Yorii-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5bc4\u5c45\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672807,
-        1108740521
+        1108740521,
+        85672807
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520405,
-    "wof:lastmodified":1566726387,
-    "wof:name":"Yorii-machi",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Yorii",
     "wof:parent_id":1108740521,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/419/890520419.geojson
+++ b/data/890/520/419/890520419.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yabuki"
+    ],
+    "name:eng_x_variant":[
+        "Yabuki-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u77e2\u5439\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672835,
-        1108740223
+        1108740223,
+        85672835
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520419,
-    "wof:lastmodified":1566726384,
-    "wof:name":"Yabuki-machi",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Yabuki",
     "wof:parent_id":1108740223,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/425/890520425.geojson
+++ b/data/890/520/425/890520425.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yakushima"
+    ],
+    "name:eng_x_variant":[
+        "Yakushima-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5c4b\u4e45\u5cf6\u753a"
     ],
@@ -42,8 +48,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672861,
-        1108743343
+        1108743343,
+        85672861
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -63,8 +69,8 @@
         }
     ],
     "wof:id":890520425,
-    "wof:lastmodified":1566726377,
-    "wof:name":"Yakushima-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Yakushima",
     "wof:parent_id":1108743343,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/455/890520455.geojson
+++ b/data/890/520/455/890520455.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kaisei"
+    ],
+    "name:eng_x_variant":[
+        "Kaisei-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u958b\u6210\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672805,
-        1108741813
+        1108741813,
+        85672805
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520455,
-    "wof:lastmodified":1566726379,
-    "wof:name":"Kaisei-machi",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Kaisei",
     "wof:parent_id":1108741813,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/459/890520459.geojson
+++ b/data/890/520/459/890520459.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Hirokawa"
+    ],
+    "name:eng_x_variant":[
+        "Hirokawa-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5e83\u5ddd\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672697,
-        1108743069
+        1108743069,
+        85672697
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520459,
-    "wof:lastmodified":1566726388,
-    "wof:name":"Hirokawa-machi",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Hirokawa",
     "wof:parent_id":1108743069,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/463/890520463.geojson
+++ b/data/890/520/463/890520463.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Keisen"
+    ],
+    "name:eng_x_variant":[
+        "Keisen-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u6842\u5ddd\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672697,
-        1108743059
+        1108743059,
+        85672697
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520463,
-    "wof:lastmodified":1566726379,
-    "wof:name":"Keisen-machi",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Keisen",
     "wof:parent_id":1108743059,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/467/890520467.geojson
+++ b/data/890/520/467/890520467.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Miyaki"
+    ],
+    "name:eng_x_variant":[
+        "Miyaki-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u307f\u3084\u304d\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672695,
-        1108743115
+        1108743115,
+        85672695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520467,
-    "wof:lastmodified":1566726386,
-    "wof:name":"Miyaki-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Miyaki",
     "wof:parent_id":1108743115,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/469/890520469.geojson
+++ b/data/890/520/469/890520469.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "\u014cmachi"
+    ],
+    "name:eng_x_variant":[
+        "\u014cmachi-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5927\u753a\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672695,
-        1108743121
+        1108743121,
+        85672695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520469,
-    "wof:lastmodified":1566726386,
-    "wof:name":"\u014cmachi-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"\u014cmachi",
     "wof:parent_id":1108743121,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/473/890520473.geojson
+++ b/data/890/520/473/890520473.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Tara"
+    ],
+    "name:eng_x_variant":[
+        "Tara-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u592a\u826f\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672695,
-        1108743127
+        1108743127,
+        85672695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520473,
-    "wof:lastmodified":1566726386,
-    "wof:name":"Tara-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Tara",
     "wof:parent_id":1108743127,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/477/890520477.geojson
+++ b/data/890/520/477/890520477.geojson
@@ -43,6 +43,9 @@
     "name:eng_x_preferred":[
         "Yoshinogari"
     ],
+    "name:eng_x_variant":[
+        "Yoshinogari-ch\u014d"
+    ],
     "name:fas_x_preferred":[
         "\u06cc\u0648\u0634\u06cc\u0646\u0648\u06af\u0627\u0631\u06cc"
     ],
@@ -106,8 +109,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672695,
-        1108743107
+        1108743107,
+        85672695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -129,8 +132,8 @@
         }
     ],
     "wof:id":890520477,
-    "wof:lastmodified":1690937872,
-    "wof:name":"Yoshinogari-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Yoshinogari",
     "wof:parent_id":1108743107,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/479/890520479.geojson
+++ b/data/890/520/479/890520479.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Fukaura"
+    ],
+    "name:eng_x_variant":[
+        "Fukaura-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u6df1\u6d66\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672831,
-        1108739881
+        1108739881,
+        85672831
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520479,
-    "wof:lastmodified":1566726377,
-    "wof:name":"Fukaura-machi",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Fukaura",
     "wof:parent_id":1108739881,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/481/890520481.geojson
+++ b/data/890/520/481/890520481.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Noheji"
+    ],
+    "name:eng_x_variant":[
+        "Noheji-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u91ce\u8fba\u5730\u753a"
     ],
@@ -48,8 +54,8 @@
         }
     ],
     "wof:id":890520481,
-    "wof:lastmodified":1566726385,
-    "wof:name":"Noheji-machi",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Noheji",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/483/890520483.geojson
+++ b/data/890/520/483/890520483.geojson
@@ -43,6 +43,9 @@
     "name:eng_x_preferred":[
         "Rokunohe"
     ],
+    "name:eng_x_variant":[
+        "Rokunohe Machi"
+    ],
     "name:fas_x_preferred":[
         "\u0631\u0648\u06a9\u0648\u0646\u0648\u0647\u0647"
     ],
@@ -128,8 +131,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672831,
-        1108739903
+        1108739903,
+        85672831
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -151,8 +154,8 @@
         }
     ],
     "wof:id":890520483,
-    "wof:lastmodified":1690937872,
-    "wof:name":"Rokunohe Machi",
+    "wof:lastmodified":1730271559,
+    "wof:name":"Rokunohe",
     "wof:parent_id":1108739903,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/485/890520485.geojson
+++ b/data/890/520/485/890520485.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "T\u014dh\u014d"
+    ],
+    "name:eng_x_variant":[
+        "T\u014dh\u014d-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u6771\u5cf0\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672697,
-        1108743063
+        1108743063,
+        85672697
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520485,
-    "wof:lastmodified":1566726376,
-    "wof:name":"T\u014dh\u014d-mura",
+    "wof:lastmodified":1730094986,
+    "wof:name":"T\u014dh\u014d",
     "wof:parent_id":1108743063,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/487/890520487.geojson
+++ b/data/890/520/487/890520487.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kudoyama"
+    ],
+    "name:eng_x_variant":[
+        "Kudoyama-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u4e5d\u5ea6\u5c71\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672795,
-        1108742639
+        1108742639,
+        85672795
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520487,
-    "wof:lastmodified":1566726386,
-    "wof:name":"Kudoyama-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Kudoyama",
     "wof:parent_id":1108742639,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/491/890520491.geojson
+++ b/data/890/520/491/890520491.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Minabe"
+    ],
+    "name:eng_x_variant":[
+        "Minabe-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u307f\u306a\u3079\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672795,
-        1108742657
+        1108742657,
+        85672795
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520491,
-    "wof:lastmodified":1566726380,
-    "wof:name":"Minabe-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Minabe",
     "wof:parent_id":1108742657,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/493/890520493.geojson
+++ b/data/890/520/493/890520493.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kamitonda"
+    ],
+    "name:eng_x_variant":[
+        "Kamitonda-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u4e0a\u5bcc\u7530\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672795,
-        1108742665
+        1108742665,
+        85672795
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520493,
-    "wof:lastmodified":1566726386,
-    "wof:name":"Kamitonda-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Kamitonda",
     "wof:parent_id":1108742665,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/499/890520499.geojson
+++ b/data/890/520/499/890520499.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Fudai"
+    ],
+    "name:eng_x_variant":[
+        "Fudai-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u666e\u4ee3\u6751"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672839,
-        1108739983
+        1108739983,
+        85672839
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520499,
-    "wof:lastmodified":1566726379,
-    "wof:name":"Fudai-mura",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Fudai",
     "wof:parent_id":1108739983,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/515/890520515.geojson
+++ b/data/890/520/515/890520515.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Fus\u014d"
+    ],
+    "name:eng_x_variant":[
+        "Fus\u014d-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u6276\u6851\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672731,
-        1108742287
+        1108742287,
+        85672731
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520515,
-    "wof:lastmodified":1566726390,
-    "wof:name":"Fus\u014d-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Fus\u014d",
     "wof:parent_id":1108742287,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/517/890520517.geojson
+++ b/data/890/520/517/890520517.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "T\u014dei"
+    ],
+    "name:eng_x_variant":[
+        "T\u014dei-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u6771\u6804\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672731,
-        1108742311
+        1108742311,
+        85672731
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520517,
-    "wof:lastmodified":1566726381,
-    "wof:name":"T\u014dei-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"T\u014dei",
     "wof:parent_id":1108742311,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/519/890520519.geojson
+++ b/data/890/520/519/890520519.geojson
@@ -40,6 +40,9 @@
     "name:eng_x_preferred":[
         "Higashiura"
     ],
+    "name:eng_x_variant":[
+        "Higashiura-ch\u014d"
+    ],
     "name:fas_x_preferred":[
         "\u0647\u06cc\u06af\u0627\u0634\u06cc\u0626\u0648\u0631\u0627"
     ],
@@ -113,8 +116,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672731,
-        1108742297
+        1108742297,
+        85672731
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -136,8 +139,8 @@
         }
     ],
     "wof:id":890520519,
-    "wof:lastmodified":1690937884,
-    "wof:name":"Higashiura-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Higashiura",
     "wof:parent_id":1108742297,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/521/890520521.geojson
+++ b/data/890/520/521/890520521.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kanie"
+    ],
+    "name:eng_x_variant":[
+        "Kanie-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u87f9\u6c5f\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672731,
-        1108742291
+        1108742291,
+        85672731
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520521,
-    "wof:lastmodified":1566726381,
-    "wof:name":"Kanie-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Kanie",
     "wof:parent_id":1108742291,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/523/890520523.geojson
+++ b/data/890/520/523/890520523.geojson
@@ -40,6 +40,9 @@
     "name:eng_x_preferred":[
         "Minamichita"
     ],
+    "name:eng_x_variant":[
+        "Minamichita-ch\u014d"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u06cc\u0646\u0627\u0645\u06cc\u200c\u0686\u06cc\u062a\u0627"
     ],
@@ -112,8 +115,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672731,
-        1108742303
+        1108742303,
+        85672731
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -135,8 +138,8 @@
         }
     ],
     "wof:id":890520523,
-    "wof:lastmodified":1690937913,
-    "wof:name":"Minamichita-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Minamichita",
     "wof:parent_id":1108742303,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/529/890520529.geojson
+++ b/data/890/520/529/890520529.geojson
@@ -22,6 +22,9 @@
     "name:eng_x_preferred":[
         "Sera"
     ],
+    "name:eng_x_variant":[
+        "Sera-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u4e16\u7f85\u753a"
     ],
@@ -36,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672671,
-        1108742819
+        1108742819,
+        85672671
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +60,8 @@
         }
     ],
     "wof:id":890520529,
-    "wof:lastmodified":1566726382,
-    "wof:name":"Sera-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Sera",
     "wof:parent_id":1108742819,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/537/890520537.geojson
+++ b/data/890/520/537/890520537.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Satosh\u014d"
+    ],
+    "name:eng_x_variant":[
+        "Satosh\u014d-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u91cc\u5e84\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672675,
-        1108742763
+        1108742763,
+        85672675
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520537,
-    "wof:lastmodified":1566726383,
-    "wof:name":"Satosh\u014d-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Satosh\u014d",
     "wof:parent_id":1108742763,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/539/890520539.geojson
+++ b/data/890/520/539/890520539.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Wake"
+    ],
+    "name:eng_x_variant":[
+        "Wake-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u548c\u6c17\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672675,
-        1108742759
+        1108742759,
+        85672675
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520539,
-    "wof:lastmodified":1566726383,
-    "wof:name":"Wake-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Wake",
     "wof:parent_id":1108742759,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/545/890520545.geojson
+++ b/data/890/520/545/890520545.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Ino"
+    ],
+    "name:eng_x_variant":[
+        "Ino-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u3044\u306e\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672717,
-        1108742973
+        1108742973,
+        85672717
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520545,
-    "wof:lastmodified":1566726382,
-    "wof:name":"Ino-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Ino",
     "wof:parent_id":1108742973,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/547/890520547.geojson
+++ b/data/890/520/547/890520547.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Ochi"
+    ],
+    "name:eng_x_variant":[
+        "Ochi-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u8d8a\u77e5\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672717,
-        1108742981
+        1108742981,
+        85672717
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520547,
-    "wof:lastmodified":1566726389,
-    "wof:name":"Ochi-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Ochi",
     "wof:parent_id":1108742981,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/549/890520549.geojson
+++ b/data/890/520/549/890520549.geojson
@@ -40,6 +40,9 @@
     "name:eng_x_preferred":[
         "Higashimiyoshi"
     ],
+    "name:eng_x_variant":[
+        "Higashimiyoshi-ch\u014d"
+    ],
     "name:fas_x_preferred":[
         "\u0647\u06cc\u06af\u0627\u0634\u06cc\u200c\u0645\u06cc\u0648\u0634\u06cc"
     ],
@@ -100,8 +103,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672729,
-        1108742881
+        1108742881,
+        85672729
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -123,8 +126,8 @@
         }
     ],
     "wof:id":890520549,
-    "wof:lastmodified":1690937907,
-    "wof:name":"Higashimiyoshi-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Higashimiyoshi",
     "wof:parent_id":1108742881,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/557/890520557.geojson
+++ b/data/890/520/557/890520557.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kumiyama"
+    ],
+    "name:eng_x_variant":[
+        "Kumiyama-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u4e45\u5fa1\u5c71\u753a"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672777,
-        1108742417
+        1108742417,
+        85672777
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890520557,
-    "wof:lastmodified":1566726375,
-    "wof:name":"Kumiyama-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Kumiyama",
     "wof:parent_id":1108742417,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/559/890520559.geojson
+++ b/data/890/520/559/890520559.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yamagata"
+    ],
+    "name:eng_x_variant":[
+        "Yamagata-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u5c71\u5f62\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672749,
-        1108742087
+        1108742087,
+        85672749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520559,
-    "wof:lastmodified":1566726375,
-    "wof:name":"Yamagata-mura",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Yamagata",
     "wof:parent_id":1108742087,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/565/890520565.geojson
+++ b/data/890/520/565/890520565.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Ikeda"
+    ],
+    "name:eng_x_variant":[
+        "Ikeda-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u6c60\u7530\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672749,
-        1108742093
+        1108742093,
+        85672749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520565,
-    "wof:lastmodified":1566726384,
-    "wof:name":"Ikeda-machi",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Ikeda",
     "wof:parent_id":1108742093,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/567/890520567.geojson
+++ b/data/890/520/567/890520567.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kannami"
+    ],
+    "name:eng_x_variant":[
+        "Kannami-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u51fd\u5357\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672753,
-        1108742223
+        1108742223,
+        85672753
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520567,
-    "wof:lastmodified":1566726374,
-    "wof:name":"Kannami-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Kannami",
     "wof:parent_id":1108742223,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/569/890520569.geojson
+++ b/data/890/520/569/890520569.geojson
@@ -40,6 +40,9 @@
     "name:eng_x_preferred":[
         "Kawanehon"
     ],
+    "name:eng_x_variant":[
+        "Kawanehon-ch\u014d"
+    ],
     "name:fas_x_preferred":[
         "\u06a9\u0627\u0648\u0627\u0646\u0647\u200c\u0647\u0648\u0646"
     ],
@@ -97,8 +100,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672753,
-        1108742235
+        1108742235,
+        85672753
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -120,8 +123,8 @@
         }
     ],
     "wof:id":890520569,
-    "wof:lastmodified":1690937863,
-    "wof:name":"Kawanehon-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Kawanehon",
     "wof:parent_id":1108742235,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/571/890520571.geojson
+++ b/data/890/520/571/890520571.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Matsuzaki"
+    ],
+    "name:eng_x_variant":[
+        "Matsuzaki-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u677e\u5d0e\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672753,
-        1108742219
+        1108742219,
+        85672753
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520571,
-    "wof:lastmodified":1566726388,
-    "wof:name":"Matsuzaki-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Matsuzaki",
     "wof:parent_id":1108742219,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/573/890520573.geojson
+++ b/data/890/520/573/890520573.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Hidaka"
+    ],
+    "name:eng_x_variant":[
+        "Hidaka-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u65e5\u9ad8\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739775
+        1108739775,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520573,
-    "wof:lastmodified":1566726382,
-    "wof:name":"Hidaka-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Hidaka",
     "wof:parent_id":1108739775,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/575/890520575.geojson
+++ b/data/890/520/575/890520575.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Biei"
+    ],
+    "name:eng_x_variant":[
+        "Biei-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u7f8e\u745b\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739657
+        1108739657,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520575,
-    "wof:lastmodified":1566726381,
-    "wof:name":"Biei-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Biei",
     "wof:parent_id":1108739657,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/581/890520581.geojson
+++ b/data/890/520/581/890520581.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Imakane"
+    ],
+    "name:eng_x_variant":[
+        "Imakane-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u4eca\u91d1\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739563
+        1108739563,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520581,
-    "wof:lastmodified":1566726381,
-    "wof:name":"Imakane-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Imakane",
     "wof:parent_id":1108739563,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/583/890520583.geojson
+++ b/data/890/520/583/890520583.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Iwanai"
+    ],
+    "name:eng_x_variant":[
+        "Iwanai-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5ca9\u5185\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739593
+        1108739593,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520583,
-    "wof:lastmodified":1566726390,
-    "wof:name":"Iwanai-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Iwanai",
     "wof:parent_id":1108739593,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/585/890520585.geojson
+++ b/data/890/520/585/890520585.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kuriyama"
+    ],
+    "name:eng_x_variant":[
+        "Kuriyama-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u6817\u5c71\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739623
+        1108739623,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520585,
-    "wof:lastmodified":1566726389,
-    "wof:name":"Kuriyama-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Kuriyama",
     "wof:parent_id":1108739623,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/587/890520587.geojson
+++ b/data/890/520/587/890520587.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Ky\u014dwa"
+    ],
+    "name:eng_x_variant":[
+        "Ky\u014dwa-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5171\u548c\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739591
+        1108739591,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520587,
-    "wof:lastmodified":1566726382,
-    "wof:name":"Ky\u014dwa-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Ky\u014dwa",
     "wof:parent_id":1108739591,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/589/890520589.geojson
+++ b/data/890/520/589/890520589.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Makubetsu"
+    ],
+    "name:eng_x_variant":[
+        "Makubetsu-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5e55\u5225\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739815
+        1108739815,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520589,
-    "wof:lastmodified":1566726382,
-    "wof:name":"Makubetsu-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Makubetsu",
     "wof:parent_id":1108739815,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/591/890520591.geojson
+++ b/data/890/520/591/890520591.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Memuro"
+    ],
+    "name:eng_x_variant":[
+        "Memuro-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u82bd\u5ba4\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739805
+        1108739805,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520591,
-    "wof:lastmodified":1566726384,
-    "wof:name":"Memuro-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Memuro",
     "wof:parent_id":1108739805,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/593/890520593.geojson
+++ b/data/890/520/593/890520593.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Moseushi"
+    ],
+    "name:eng_x_variant":[
+        "Moseushi-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u59b9\u80cc\u725b\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739631
+        1108739631,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520593,
-    "wof:lastmodified":1566726374,
-    "wof:name":"Moseushi-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Moseushi",
     "wof:parent_id":1108739631,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/601/890520601.geojson
+++ b/data/890/520/601/890520601.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Teshikaga"
+    ],
+    "name:eng_x_variant":[
+        "Teshikaga-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5f1f\u5b50\u5c48\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739839
+        1108739839,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520601,
-    "wof:lastmodified":1566726387,
-    "wof:name":"Teshikaga-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Teshikaga",
     "wof:parent_id":1108739839,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/603/890520603.geojson
+++ b/data/890/520/603/890520603.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nishiwaga"
+    ],
+    "name:eng_x_variant":[
+        "Nishiwaga-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u897f\u548c\u8cc0\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672839,
-        1108739965
+        1108739965,
+        85672839
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520603,
-    "wof:lastmodified":1566726380,
-    "wof:name":"Nishiwaga-machi",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Nishiwaga",
     "wof:parent_id":1108739965,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/605/890520605.geojson
+++ b/data/890/520/605/890520605.geojson
@@ -40,6 +40,9 @@
     "name:eng_x_preferred":[
         "Shizukuishi"
     ],
+    "name:eng_x_variant":[
+        "Shizukuishi-ch\u014d"
+    ],
     "name:fas_x_preferred":[
         "\u0634\u06cc\u0632\u0648\u06a9\u0648\u0627\u06cc\u0634\u06cc"
     ],
@@ -112,8 +115,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672839,
-        1108739953
+        1108739953,
+        85672839
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -135,8 +138,8 @@
         }
     ],
     "wof:id":890520605,
-    "wof:lastmodified":1690937876,
-    "wof:name":"Shizukuishi-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Shizukuishi",
     "wof:parent_id":1108739953,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/607/890520607.geojson
+++ b/data/890/520/607/890520607.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Minamisanriku"
+    ],
+    "name:eng_x_variant":[
+        "Minamisanriku-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5357\u4e09\u9678\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672843,
-        1108740047
+        1108740047,
+        85672843
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520607,
-    "wof:lastmodified":1566726388,
-    "wof:name":"Minamisanriku-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Minamisanriku",
     "wof:parent_id":1108740047,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/609/890520609.geojson
+++ b/data/890/520/609/890520609.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Misato"
+    ],
+    "name:eng_x_variant":[
+        "Misato-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u7f8e\u91cc\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672843,
-        890524897
+        890524897,
+        85672843
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520609,
-    "wof:lastmodified":1566726388,
-    "wof:name":"Misato-machi",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Misato",
     "wof:parent_id":890524897,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/613/890520613.geojson
+++ b/data/890/520/613/890520613.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "\u014cgawara"
+    ],
+    "name:eng_x_variant":[
+        "\u014cgawara-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5927\u6cb3\u539f\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672843,
-        1108740007
+        1108740007,
+        85672843
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520613,
-    "wof:lastmodified":1566726384,
-    "wof:name":"\u014cgawara-machi",
+    "wof:lastmodified":1730094987,
+    "wof:name":"\u014cgawara",
     "wof:parent_id":1108740007,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/617/890520617.geojson
+++ b/data/890/520/617/890520617.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Tomiya"
+    ],
+    "name:eng_x_variant":[
+        "Tomiya-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5bcc\u8c37\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672843,
-        1108740031
+        1108740031,
+        85672843
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520617,
-    "wof:lastmodified":1566726377,
-    "wof:name":"Tomiya-machi",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Tomiya",
     "wof:parent_id":1108740031,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/619/890520619.geojson
+++ b/data/890/520/619/890520619.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kaneyama"
+    ],
+    "name:eng_x_variant":[
+        "Kaneyama-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u91d1\u5c71\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672853,
-        1108740121
+        1108740121,
+        85672853
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520619,
-    "wof:lastmodified":1566726377,
-    "wof:name":"Kaneyama-machi",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Kaneyama",
     "wof:parent_id":1108740121,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/621/890520621.geojson
+++ b/data/890/520/621/890520621.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Mibu"
+    ],
+    "name:eng_x_variant":[
+        "Mibu-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u58ec\u751f\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672813,
-        1108740345
+        1108740345,
+        85672813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520621,
-    "wof:lastmodified":1566726377,
-    "wof:name":"Mibu-machi",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Mibu",
     "wof:parent_id":1108740345,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/623/890520623.geojson
+++ b/data/890/520/623/890520623.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Motegi"
+    ],
+    "name:eng_x_variant":[
+        "Motegi-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u8302\u6728\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672813,
-        1108740337
+        1108740337,
+        85672813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520623,
-    "wof:lastmodified":1566726385,
-    "wof:name":"Motegi-machi",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Motegi",
     "wof:parent_id":1108740337,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/625/890520625.geojson
+++ b/data/890/520/625/890520625.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nakagawa"
+    ],
+    "name:eng_x_variant":[
+        "Nakagawa-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u90a3\u73c2\u5ddd\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672813,
-        1108740355
+        1108740355,
+        85672813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520625,
-    "wof:lastmodified":1566726385,
-    "wof:name":"Nakagawa-machi",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Nakagawa",
     "wof:parent_id":1108740355,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/635/890520635.geojson
+++ b/data/890/520/635/890520635.geojson
@@ -56,7 +56,8 @@
         "\u014camishirasato"
     ],
     "name:eng_x_variant":[
-        "Oamishirasato"
+        "Oamishirasato",
+        "\u014camishirasato-machi"
     ],
     "name:est_x_preferred":[
         "\u014camishirasato"
@@ -190,8 +191,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672797,
-        1108741649
+        1108741649,
+        85672797
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -213,8 +214,8 @@
         }
     ],
     "wof:id":890520635,
-    "wof:lastmodified":1690937880,
-    "wof:name":"\u014camishirasato-machi",
+    "wof:lastmodified":1730094986,
+    "wof:name":"\u014camishirasato",
     "wof:parent_id":1108741649,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/637/890520637.geojson
+++ b/data/890/520/637/890520637.geojson
@@ -46,6 +46,9 @@
     "name:eng_x_preferred":[
         "Yokoshibahikari"
     ],
+    "name:eng_x_variant":[
+        "Yokoshibahikari-machi"
+    ],
     "name:fas_x_preferred":[
         "\u06cc\u0648\u06a9\u0648\u0634\u06cc\u0628\u0627\u0647\u06cc\u06a9\u0627\u0631\u06cc"
     ],
@@ -115,8 +118,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672797,
-        1108741657
+        1108741657,
+        85672797
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -138,8 +141,8 @@
         }
     ],
     "wof:id":890520637,
-    "wof:lastmodified":1690937902,
-    "wof:name":"Yokoshibahikari-machi",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Yokoshibahikari",
     "wof:parent_id":1108741657,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/639/890520639.geojson
+++ b/data/890/520/639/890520639.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Shirako"
+    ],
+    "name:eng_x_variant":[
+        "Shirako-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u767d\u5b50\u753a"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672797,
-        1108741665
+        1108741665,
+        85672797
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890520639,
-    "wof:lastmodified":1566726387,
-    "wof:name":"Shirako-machi",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Shirako",
     "wof:parent_id":1108741665,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/641/890520641.geojson
+++ b/data/890/520/641/890520641.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "\u014ctaki"
+    ],
+    "name:eng_x_variant":[
+        "\u014ctaki-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5927\u591a\u559c\u753a"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672797,
-        1108741673
+        1108741673,
+        85672797
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890520641,
-    "wof:lastmodified":1566726386,
-    "wof:name":"\u014ctaki-machi",
+    "wof:lastmodified":1730094987,
+    "wof:name":"\u014ctaki",
     "wof:parent_id":1108741673,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/643/890520643.geojson
+++ b/data/890/520/643/890520643.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kyonan"
+    ],
+    "name:eng_x_variant":[
+        "Kyonan-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u92f8\u5357\u753a"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672797,
-        1108741677
+        1108741677,
+        85672797
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890520643,
-    "wof:lastmodified":1566726376,
-    "wof:name":"Kyonan-machi",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Kyonan",
     "wof:parent_id":1108741677,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/645/890520645.geojson
+++ b/data/890/520/645/890520645.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yamakita"
+    ],
+    "name:eng_x_variant":[
+        "Yamakita-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5c71\u5317\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672805,
-        1108741811
+        1108741811,
+        85672805
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520645,
-    "wof:lastmodified":1566726377,
-    "wof:name":"Yamakita-machi",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Yamakita",
     "wof:parent_id":1108741811,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/655/890520655.geojson
+++ b/data/890/520/655/890520655.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kihoku"
+    ],
+    "name:eng_x_variant":[
+        "Kihoku-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u7d00\u5317\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672745,
-        1108742353
+        1108742353,
+        85672745
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520655,
-    "wof:lastmodified":1566726386,
-    "wof:name":"Kihoku-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Kihoku",
     "wof:parent_id":1108742353,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/745/890520745.geojson
+++ b/data/890/520/745/890520745.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yoshida"
+    ],
+    "name:eng_x_variant":[
+        "Yoshida-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5409\u7530\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672753,
-        1108742233
+        1108742233,
+        85672753
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520745,
-    "wof:lastmodified":1566726390,
-    "wof:name":"Yoshida-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Yoshida",
     "wof:parent_id":1108742233,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/747/890520747.geojson
+++ b/data/890/520/747/890520747.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yoron"
+    ],
+    "name:eng_x_variant":[
+        "Yoron-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u4e0e\u8ad6\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672861,
-        1108743369
+        1108743369,
+        85672861
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520747,
-    "wof:lastmodified":1566726381,
-    "wof:name":"Yoron-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Yoron",
     "wof:parent_id":1108743369,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/755/890520755.geojson
+++ b/data/890/520/755/890520755.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nishihara"
+    ],
+    "name:eng_x_variant":[
+        "Nishihara-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u897f\u539f\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672867,
-        1108743415
+        1108743415,
+        85672867
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520755,
-    "wof:lastmodified":1566726374,
-    "wof:name":"Nishihara-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Nishihara",
     "wof:parent_id":1108743415,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/773/890520773.geojson
+++ b/data/890/520/773/890520773.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Niseko"
+    ],
+    "name:eng_x_variant":[
+        "Niseko-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u30cb\u30bb\u30b3\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739577
+        1108739577,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520773,
-    "wof:lastmodified":1566726389,
-    "wof:name":"Niseko-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Niseko",
     "wof:parent_id":1108739577,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/799/890520799.geojson
+++ b/data/890/520/799/890520799.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Sakekawa"
+    ],
+    "name:eng_x_variant":[
+        "Sakekawa-mura"
+    ],
     "name:und_x_variant":[
         "Sakegawa"
     ],
@@ -30,8 +36,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672853,
-        1108740133
+        1108740133,
+        85672853
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -51,8 +57,8 @@
         }
     ],
     "wof:id":890520799,
-    "wof:lastmodified":1566726374,
-    "wof:name":"Sakekawa-mura",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Sakekawa",
     "wof:parent_id":1108740133,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/817/890520817.geojson
+++ b/data/890/520/817/890520817.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Happ\u014d"
+    ],
+    "name:eng_x_variant":[
+        "Happ\u014d-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u516b\u5cf0\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672825,
-        1108740067
+        1108740067,
+        85672825
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520817,
-    "wof:lastmodified":1566726377,
-    "wof:name":"Happ\u014d-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Happ\u014d",
     "wof:parent_id":1108740067,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/819/890520819.geojson
+++ b/data/890/520/819/890520819.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Oyagawa"
+    ],
+    "name:eng_x_variant":[
+        "Oyagawa-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u7dbe\u5ddd\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672715,
-        1108742901
+        1108742901,
+        85672715
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520819,
-    "wof:lastmodified":1566726378,
-    "wof:name":"Oyagawa-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Oyagawa",
     "wof:parent_id":1108742901,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/821/890520821.geojson
+++ b/data/890/520/821/890520821.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kotohira"
+    ],
+    "name:eng_x_variant":[
+        "Kotohira-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u7434\u5e73\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672715,
-        1108742903
+        1108742903,
+        85672715
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520821,
-    "wof:lastmodified":1566726377,
-    "wof:name":"Kotohira-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Kotohira",
     "wof:parent_id":1108742903,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/833/890520833.geojson
+++ b/data/890/520/833/890520833.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Aridagawa"
+    ],
+    "name:eng_x_variant":[
+        "Aridagawa-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u6709\u7530\u5ddd\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672795,
-        1108742647
+        1108742647,
+        85672795
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520833,
-    "wof:lastmodified":1566726380,
-    "wof:name":"Aridagawa-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Aridagawa",
     "wof:parent_id":1108742647,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/835/890520835.geojson
+++ b/data/890/520/835/890520835.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kimino"
+    ],
+    "name:eng_x_variant":[
+        "Kimino-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u7d00\u7f8e\u91ce\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672795,
-        1108742633
+        1108742633,
+        85672795
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520835,
-    "wof:lastmodified":1566726379,
-    "wof:name":"Kimino-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Kimino",
     "wof:parent_id":1108742633,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/837/890520837.geojson
+++ b/data/890/520/837/890520837.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "K\u014dya"
+    ],
+    "name:eng_x_variant":[
+        "K\u014dya-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u9ad8\u91ce\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672795,
-        1108742639
+        1108742639,
+        85672795
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520837,
-    "wof:lastmodified":1566726387,
-    "wof:name":"K\u014dya-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"K\u014dya",
     "wof:parent_id":1108742639,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/851/890520851.geojson
+++ b/data/890/520/851/890520851.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Wanouchi"
+    ],
+    "name:eng_x_variant":[
+        "Wanouchi-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u8f2a\u4e4b\u5185\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672735,
-        1108742151
+        1108742151,
+        85672735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520851,
-    "wof:lastmodified":1566726379,
-    "wof:name":"Wanouchi-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Wanouchi",
     "wof:parent_id":1108742151,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/855/890520855.geojson
+++ b/data/890/520/855/890520855.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Misato"
+    ],
+    "name:eng_x_variant":[
+        "Misato-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u7f8e\u90f7\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672825,
-        1108740079
+        1108740079,
+        85672825
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520855,
-    "wof:lastmodified":1566726388,
-    "wof:name":"Misato-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Misato",
     "wof:parent_id":1108740079,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/857/890520857.geojson
+++ b/data/890/520/857/890520857.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Mitane"
+    ],
+    "name:eng_x_variant":[
+        "Mitane-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u4e09\u7a2e\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672825,
-        1108740065
+        1108740065,
+        85672825
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520857,
-    "wof:lastmodified":1566726378,
-    "wof:name":"Mitane-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Mitane",
     "wof:parent_id":1108740065,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/871/890520871.geojson
+++ b/data/890/520/871/890520871.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Sh\u014dnai"
+    ],
+    "name:eng_x_variant":[
+        "Sh\u014dnai-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5e84\u5185\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672853,
-        1108740149
+        1108740149,
+        85672853
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520871,
-    "wof:lastmodified":1566726385,
-    "wof:name":"Sh\u014dnai-machi",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Sh\u014dnai",
     "wof:parent_id":1108740149,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/873/890520873.geojson
+++ b/data/890/520/873/890520873.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Takahata"
+    ],
+    "name:eng_x_variant":[
+        "Takahata-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u9ad8\u7560\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672853,
-        1108740137
+        1108740137,
+        85672853
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520873,
-    "wof:lastmodified":1566726377,
-    "wof:name":"Takahata-machi",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Takahata",
     "wof:parent_id":1108740137,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/881/890520881.geojson
+++ b/data/890/520/881/890520881.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yahiko"
+    ],
+    "name:eng_x_variant":[
+        "Yahiko-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u5f25\u5f66\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672849,
-        1108741843
+        1108741843,
+        85672849
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520881,
-    "wof:lastmodified":1566726378,
-    "wof:name":"Yahiko-mura",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Yahiko",
     "wof:parent_id":1108741843,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/883/890520883.geojson
+++ b/data/890/520/883/890520883.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Aga"
+    ],
+    "name:eng_x_variant":[
+        "Aga-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u963f\u8cc0\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672849,
-        1108741847
+        1108741847,
+        85672849
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520883,
-    "wof:lastmodified":1566726385,
-    "wof:name":"Aga-machi",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Aga",
     "wof:parent_id":1108741847,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/887/890520887.geojson
+++ b/data/890/520/887/890520887.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yaese"
+    ],
+    "name:eng_x_variant":[
+        "Yaese-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u516b\u91cd\u702c\u753a"
     ],
@@ -51,8 +57,8 @@
         }
     ],
     "wof:id":890520887,
-    "wof:lastmodified":1566726377,
-    "wof:name":"Yaese-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Yaese",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/891/890520891.geojson
+++ b/data/890/520/891/890520891.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Tsukigata"
+    ],
+    "name:eng_x_variant":[
+        "Tsukigata-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u6708\u5f62\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739625
+        1108739625,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520891,
-    "wof:lastmodified":1566726387,
-    "wof:name":"Tsukigata-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Tsukigata",
     "wof:parent_id":1108739625,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/893/890520893.geojson
+++ b/data/890/520/893/890520893.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Urakawa"
+    ],
+    "name:eng_x_variant":[
+        "Urakawa-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u6d66\u6cb3\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739779
+        1108739779,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890520893,
-    "wof:lastmodified":1566726380,
-    "wof:name":"Urakawa-ch\u014d",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Urakawa",
     "wof:parent_id":1108739779,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/895/890520895.geojson
+++ b/data/890/520/895/890520895.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Oirase"
+    ],
+    "name:eng_x_variant":[
+        "Oirase Ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u304a\u3044\u3089\u305b\u753a"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672831,
-        1108739913
+        1108739913,
+        85672831
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890520895,
-    "wof:lastmodified":1566726378,
-    "wof:name":"Oirase Ch\u014d",
+    "wof:lastmodified":1730271559,
+    "wof:name":"Oirase",
     "wof:parent_id":1108739913,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/901/890520901.geojson
+++ b/data/890/520/901/890520901.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Ichinohe"
+    ],
+    "name:eng_x_variant":[
+        "Ichinohe-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u4e00\u6238\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672839,
-        1108739993
+        1108739993,
+        85672839
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520901,
-    "wof:lastmodified":1566726375,
-    "wof:name":"Ichinohe-machi",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Ichinohe",
     "wof:parent_id":1108739993,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/520/905/890520905.geojson
+++ b/data/890/520/905/890520905.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kuj\u016bkuri"
+    ],
+    "name:eng_x_variant":[
+        "Kuj\u016bkuri-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u4e5d\u5341\u4e5d\u91cc\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672797,
-        1108741651
+        1108741651,
+        85672797
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890520905,
-    "wof:lastmodified":1566726384,
-    "wof:name":"Kuj\u016bkuri-machi",
+    "wof:lastmodified":1730094986,
+    "wof:name":"Kuj\u016bkuri",
     "wof:parent_id":1108741651,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/521/007/890521007.geojson
+++ b/data/890/521/007/890521007.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Tsuwano"
+    ],
+    "name:eng_x_variant":[
+        "Tsuwano-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u6d25\u548c\u91ce\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672679,
-        1108742731
+        1108742731,
+        85672679
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890521007,
-    "wof:lastmodified":1566726314,
-    "wof:name":"Tsuwano-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Tsuwano",
     "wof:parent_id":1108742731,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/521/009/890521009.geojson
+++ b/data/890/521/009/890521009.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Akkeshi"
+    ],
+    "name:eng_x_variant":[
+        "Akkeshi-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u539a\u5cb8\u753a"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739831
+        1108739831,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890521009,
-    "wof:lastmodified":1566726314,
-    "wof:name":"Akkeshi-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Akkeshi",
     "wof:parent_id":1108739831,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/521/509/890521509.geojson
+++ b/data/890/521/509/890521509.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Hasami"
+    ],
+    "name:eng_x_variant":[
+        "Hasami-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u6ce2\u4f50\u898b\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672857,
-        1108743145
+        1108743145,
+        85672857
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890521509,
-    "wof:lastmodified":1566726318,
-    "wof:name":"Hasami-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Hasami",
     "wof:parent_id":1108743145,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/521/621/890521621.geojson
+++ b/data/890/521/621/890521621.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Karuizawa"
+    ],
+    "name:eng_x_variant":[
+        "Karuizawa-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u8efd\u4e95\u6ca2\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672749,
-        1108742007
+        1108742007,
+        85672749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890521621,
-    "wof:lastmodified":1566726312,
-    "wof:name":"Karuizawa-machi",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Karuizawa",
     "wof:parent_id":1108742007,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/522/717/890522717.geojson
+++ b/data/890/522/717/890522717.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "China"
+    ],
+    "name:eng_x_variant":[
+        "China-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u77e5\u540d\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672861,
-        1108743367
+        1108743367,
+        85672861
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890522717,
-    "wof:lastmodified":1566726468,
-    "wof:name":"China-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"China",
     "wof:parent_id":1108743367,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/522/897/890522897.geojson
+++ b/data/890/522/897/890522897.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "\u014cgimi"
+    ],
+    "name:eng_x_variant":[
+        "\u014cgimi-son"
+    ],
     "name:jpn_x_preferred":[
         "\u5927\u5b9c\u5473\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672867,
-        1108743387
+        1108743387,
+        85672867
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890522897,
-    "wof:lastmodified":1566726467,
-    "wof:name":"\u014cgimi-son",
+    "wof:lastmodified":1730094988,
+    "wof:name":"\u014cgimi",
     "wof:parent_id":1108743387,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/522/905/890522905.geojson
+++ b/data/890/522/905/890522905.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kin"
+    ],
+    "name:eng_x_variant":[
+        "Kin-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u91d1\u6b66\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672867,
-        1108743401
+        1108743401,
+        85672867
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890522905,
-    "wof:lastmodified":1566726463,
-    "wof:name":"Kin-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Kin",
     "wof:parent_id":1108743401,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/522/909/890522909.geojson
+++ b/data/890/522/909/890522909.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Ginoza"
+    ],
+    "name:eng_x_variant":[
+        "Ginoza-son"
+    ],
     "name:jpn_x_preferred":[
         "\u5b9c\u91ce\u5ea7\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672867,
-        1108743397
+        1108743397,
+        85672867
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890522909,
-    "wof:lastmodified":1566726453,
-    "wof:name":"Ginoza-son",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Ginoza",
     "wof:parent_id":1108743397,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/522/923/890522923.geojson
+++ b/data/890/522/923/890522923.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Obuse"
+    ],
+    "name:eng_x_variant":[
+        "Obuse-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5c0f\u5e03\u65bd\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672749,
-        1108742105
+        1108742105,
+        85672749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890522923,
-    "wof:lastmodified":1566726460,
-    "wof:name":"Obuse-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Obuse",
     "wof:parent_id":1108742105,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/522/925/890522925.geojson
+++ b/data/890/522/925/890522925.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yamada"
+    ],
+    "name:eng_x_variant":[
+        "Yamada-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5c71\u7530\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672839,
-        1108739975
+        1108739975,
+        85672839
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890522925,
-    "wof:lastmodified":1566726461,
-    "wof:name":"Yamada-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Yamada",
     "wof:parent_id":1108739975,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/522/927/890522927.geojson
+++ b/data/890/522/927/890522927.geojson
@@ -41,7 +41,8 @@
         "Hachir\u014dgata"
     ],
     "name:eng_x_variant":[
-        "Hachirogata"
+        "Hachirogata",
+        "Hachir\u014dgata-machi"
     ],
     "name:fas_x_preferred":[
         "\u0647\u0627\u0686\u06cc\u0631\u0648\u06af\u0627\u062a\u0627"
@@ -121,8 +122,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672825,
-        1108740073
+        1108740073,
+        85672825
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -144,8 +145,8 @@
         }
     ],
     "wof:id":890522927,
-    "wof:lastmodified":1690937941,
-    "wof:name":"Hachir\u014dgata-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Hachir\u014dgata",
     "wof:parent_id":1108740073,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/522/929/890522929.geojson
+++ b/data/890/522/929/890522929.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Ogose"
+    ],
+    "name:eng_x_variant":[
+        "Ogose-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u8d8a\u751f\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672807,
-        1108740485
+        1108740485,
+        85672807
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890522929,
-    "wof:lastmodified":1566726468,
-    "wof:name":"Ogose-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Ogose",
     "wof:parent_id":1108740485,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/522/931/890522931.geojson
+++ b/data/890/522/931/890522931.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Ogawa"
+    ],
+    "name:eng_x_variant":[
+        "Ogawa-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5c0f\u5ddd\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672807,
-        1108740491
+        1108740491,
+        85672807
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890522931,
-    "wof:lastmodified":1566726453,
-    "wof:name":"Ogawa-machi",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Ogawa",
     "wof:parent_id":1108740491,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/522/935/890522935.geojson
+++ b/data/890/522/935/890522935.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kami"
+    ],
+    "name:eng_x_variant":[
+        "Kami-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u52a0\u7f8e\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672843,
-        1108740039
+        1108740039,
+        85672843
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890522935,
-    "wof:lastmodified":1566726462,
-    "wof:name":"Kami-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Kami",
     "wof:parent_id":1108740039,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/287/890523287.geojson
+++ b/data/890/523/287/890523287.geojson
@@ -20,6 +20,10 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "name:eng_x_preferred":[
+        "Kamikawa"
+    ],
+    "name:eng_x_variant":[
+        "Kamikawa-mura",
         "Kamikawa-machi"
     ],
     "name:jpn_x_preferred":[
@@ -36,8 +40,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672807,
-        1108740515
+        1108740515,
+        85672807
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +61,8 @@
         }
     ],
     "wof:id":890523287,
-    "wof:lastmodified":1566726473,
-    "wof:name":"Kamikawa-mura",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Kamikawa",
     "wof:parent_id":1108740515,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/291/890523291.geojson
+++ b/data/890/523/291/890523291.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Ie"
+    ],
+    "name:eng_x_variant":[
+        "Ie-son"
+    ],
     "name:jpn_x_preferred":[
         "\u4f0a\u6c5f\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672867,
-        1108743403
+        1108743403,
+        85672867
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890523291,
-    "wof:lastmodified":1566726483,
-    "wof:name":"Ie-son",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Ie",
     "wof:parent_id":1108743403,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/307/890523307.geojson
+++ b/data/890/523/307/890523307.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Ebino"
+    ],
+    "name:eng_x_variant":[
+        "Ebino-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u3048\u3073\u306e\u5e02"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672707,
-        1108743265
+        1108743265,
+        85672707
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890523307,
-    "wof:lastmodified":1566726470,
-    "wof:name":"Ebino-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Ebino",
     "wof:parent_id":1108743265,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/311/890523311.geojson
+++ b/data/890/523/311/890523311.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Shimonita"
+    ],
+    "name:eng_x_variant":[
+        "Shimonita-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u4e0b\u4ec1\u7530\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672871,
-        1108740379
+        1108740379,
+        85672871
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890523311,
-    "wof:lastmodified":1566726484,
-    "wof:name":"Shimonita-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Shimonita",
     "wof:parent_id":1108740379,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/313/890523313.geojson
+++ b/data/890/523/313/890523313.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Tamamura"
+    ],
+    "name:eng_x_variant":[
+        "Tamamura-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u7389\u6751\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672871,
-        1108740407
+        1108740407,
+        85672871
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890523313,
-    "wof:lastmodified":1566726477,
-    "wof:name":"Tamamura-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Tamamura",
     "wof:parent_id":1108740407,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/319/890523319.geojson
+++ b/data/890/523/319/890523319.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kawagoe"
+    ],
+    "name:eng_x_variant":[
+        "Kawagoe-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5ddd\u8d8a\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672745,
-        1108742335
+        1108742335,
+        85672745
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890523319,
-    "wof:lastmodified":1566726486,
-    "wof:name":"Kawagoe-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Kawagoe",
     "wof:parent_id":1108742335,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/707/890523707.geojson
+++ b/data/890/523/707/890523707.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Zamami"
+    ],
+    "name:eng_x_variant":[
+        "Zamami-son"
+    ],
     "name:jpn_x_preferred":[
         "\u5ea7\u9593\u5473\u6751"
     ],
@@ -51,8 +57,8 @@
         }
     ],
     "wof:id":890523707,
-    "wof:lastmodified":1566726472,
-    "wof:name":"Zamami-son",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Zamami",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/709/890523709.geojson
+++ b/data/890/523/709/890523709.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yugawa"
+    ],
+    "name:eng_x_variant":[
+        "Yugawa-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u6e6f\u5ddd\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672835,
-        1108740203
+        1108740203,
+        85672835
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890523709,
-    "wof:lastmodified":1566726471,
-    "wof:name":"Yugawa-mura",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Yugawa",
     "wof:parent_id":1108740203,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/713/890523713.geojson
+++ b/data/890/523/713/890523713.geojson
@@ -23,10 +23,11 @@
         "Yoshimi-mura"
     ],
     "name:eng_x_preferred":[
-        "Yoshimi-mura"
+        "Yoshimi"
     ],
     "name:eng_x_variant":[
-        "Yoshimi-machi"
+        "Yoshimi-machi",
+        "Yoshimi-mura"
     ],
     "name:jpn_x_preferred":[
         "\u5409\u898b\u753a"
@@ -46,8 +47,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672807,
-        1108740495
+        1108740495,
+        85672807
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,8 +68,8 @@
         }
     ],
     "wof:id":890523713,
-    "wof:lastmodified":1566726476,
-    "wof:name":"Yoshimi-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Yoshimi",
     "wof:parent_id":1108740495,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/717/890523717.geojson
+++ b/data/890/523/717/890523717.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Y\u014dr\u014d"
+    ],
+    "name:eng_x_variant":[
+        "Y\u014dr\u014d-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "Y\u014dr\u014d-ch\u014d"
     ],
@@ -34,8 +40,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672735,
-        1108742143
+        1108742143,
+        85672735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,8 +61,8 @@
         }
     ],
     "wof:id":890523717,
-    "wof:lastmodified":1566726485,
-    "wof:name":"Y\u014dr\u014d-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Y\u014dr\u014d",
     "wof:parent_id":1108742143,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/719/890523719.geojson
+++ b/data/890/523/719/890523719.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yonaguni"
+    ],
+    "name:eng_x_variant":[
+        "Yonaguni-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u4e0e\u90a3\u56fd\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672867,
-        1108743449
+        1108743449,
+        85672867
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890523719,
-    "wof:lastmodified":1566726485,
-    "wof:name":"Yonaguni-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Yonaguni",
     "wof:parent_id":1108743449,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/721/890523721.geojson
+++ b/data/890/523/721/890523721.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Urayasu"
+    ],
+    "name:eng_x_variant":[
+        "Urayasu-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u6d66\u5b89\u5e02"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672797,
-        1108741615
+        1108741615,
+        85672797
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890523721,
-    "wof:lastmodified":1566726485,
-    "wof:name":"Urayasu-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Urayasu",
     "wof:parent_id":1108741615,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/733/890523733.geojson
+++ b/data/890/523/733/890523733.geojson
@@ -37,6 +37,9 @@
     "name:eng_x_preferred":[
         "Tenkawa"
     ],
+    "name:eng_x_variant":[
+        "Tenkawa-mura"
+    ],
     "name:fas_x_preferred":[
         "\u062a\u0646\u06a9\u0627\u0648\u0627"
     ],
@@ -88,8 +91,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672779,
-        1108742613
+        1108742613,
+        85672779
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -111,8 +114,8 @@
         }
     ],
     "wof:id":890523733,
-    "wof:lastmodified":1690937955,
-    "wof:name":"Tenkawa-mura",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Tenkawa",
     "wof:parent_id":1108742613,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/753/890523753.geojson
+++ b/data/890/523/753/890523753.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Onna"
+    ],
+    "name:eng_x_variant":[
+        "Onna-son"
+    ],
     "name:jpn_x_preferred":[
         "\u6069\u7d0d\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672867,
-        1108743395
+        1108743395,
+        85672867
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890523753,
-    "wof:lastmodified":1566726471,
-    "wof:name":"Onna-son",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Onna",
     "wof:parent_id":1108743395,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/757/890523757.geojson
+++ b/data/890/523/757/890523757.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nagakute"
+    ],
+    "name:eng_x_variant":[
+        "Nagakute-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u9577\u4e45\u624b\u5e02"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672731,
-        1108742279
+        1108742279,
+        85672731
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890523757,
-    "wof:lastmodified":1566726480,
-    "wof:name":"Nagakute-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Nagakute",
     "wof:parent_id":1108742279,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/759/890523759.geojson
+++ b/data/890/523/759/890523759.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Motobu"
+    ],
+    "name:eng_x_variant":[
+        "Motobu-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u672c\u90e8\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672867,
-        1108743393
+        1108743393,
+        85672867
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890523759,
-    "wof:lastmodified":1566726480,
-    "wof:name":"Motobu-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Motobu",
     "wof:parent_id":1108743393,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/761/890523761.geojson
+++ b/data/890/523/761/890523761.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Mizuho"
+    ],
+    "name:eng_x_variant":[
+        "Mizuho-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u745e\u7a42\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672817,
-        1108741755
+        1108741755,
+        85672817
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890523761,
-    "wof:lastmodified":1566726480,
-    "wof:name":"Mizuho-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Mizuho",
     "wof:parent_id":1108741755,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/763/890523763.geojson
+++ b/data/890/523/763/890523763.geojson
@@ -46,6 +46,9 @@
     "name:eng_x_preferred":[
         "Nachikatsuura"
     ],
+    "name:eng_x_variant":[
+        "Nachikatsuura-ch\u014d"
+    ],
     "name:eus_x_preferred":[
         "Nachikatsuura"
     ],
@@ -109,8 +112,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672795,
-        1108742669
+        1108742669,
+        85672795
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -132,8 +135,8 @@
         }
     ],
     "wof:id":890523763,
-    "wof:lastmodified":1690937942,
-    "wof:name":"Nachikatsuura-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Nachikatsuura",
     "wof:parent_id":1108742669,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/775/890523775.geojson
+++ b/data/890/523/775/890523775.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Matsukawa"
+    ],
+    "name:eng_x_variant":[
+        "Matsukawa-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u677e\u5ddd\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672749,
-        1108742039
+        1108742039,
+        85672749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890523775,
-    "wof:lastmodified":1566726485,
-    "wof:name":"Matsukawa-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Matsukawa",
     "wof:parent_id":1108742039,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/795/890523795.geojson
+++ b/data/890/523/795/890523795.geojson
@@ -37,6 +37,9 @@
     "name:eng_x_preferred":[
         "Kitanakagusuku"
     ],
+    "name:eng_x_variant":[
+        "Kitanakagusuku-son"
+    ],
     "name:fas_x_preferred":[
         "\u06a9\u06cc\u062a\u0627\u0646\u0627\u06a9\u0627\u06af\u0648\u0633\u0648\u06a9\u0648"
     ],
@@ -94,8 +97,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672867,
-        1108743411
+        1108743411,
+        85672867
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -117,8 +120,8 @@
         }
     ],
     "wof:id":890523795,
-    "wof:lastmodified":1690937959,
-    "wof:name":"Kitanakagusuku-son",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Kitanakagusuku",
     "wof:parent_id":1108743411,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/817/890523817.geojson
+++ b/data/890/523/817/890523817.geojson
@@ -20,6 +20,9 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "name:eng_x_preferred":[
+        "Hakone"
+    ],
+    "name:eng_x_variant":[
         "Hakone-machi"
     ],
     "name:jpn_x_preferred":[
@@ -39,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672805,
-        1108741817
+        1108741817,
+        85672805
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -60,8 +63,8 @@
         }
     ],
     "wof:id":890523817,
-    "wof:lastmodified":1566726473,
-    "wof:name":"Hakone-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Hakone",
     "wof:parent_id":1108741817,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/827/890523827.geojson
+++ b/data/890/523/827/890523827.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Hakuba"
+    ],
+    "name:eng_x_variant":[
+        "Hakuba-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u767d\u99ac\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672749,
-        1108742097
+        1108742097,
+        85672749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890523827,
-    "wof:lastmodified":1566726472,
-    "wof:name":"Hakuba-mura",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Hakuba",
     "wof:parent_id":1108742097,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/843/890523843.geojson
+++ b/data/890/523/843/890523843.geojson
@@ -22,6 +22,9 @@
     "name:eng_x_preferred":[
         "Uchiko"
     ],
+    "name:eng_x_variant":[
+        "Uchiko-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5185\u5b50\u753a"
     ],
@@ -33,8 +36,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672711,
-        1108742927
+        1108742927,
+        85672711
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +57,8 @@
         }
     ],
     "wof:id":890523843,
-    "wof:lastmodified":1566726474,
-    "wof:name":"Uchiko-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Uchiko",
     "wof:parent_id":1108742927,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/895/890523895.geojson
+++ b/data/890/523/895/890523895.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Za\u014d"
+    ],
+    "name:eng_x_variant":[
+        "Za\u014d-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u8535\u738b\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672843,
-        1108740003
+        1108740003,
+        85672843
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890523895,
-    "wof:lastmodified":1566726474,
-    "wof:name":"Za\u014d-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Za\u014d",
     "wof:parent_id":1108740003,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/901/890523901.geojson
+++ b/data/890/523/901/890523901.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "T\u014dkai"
+    ],
+    "name:eng_x_variant":[
+        "T\u014dkai-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u6771\u6d77\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672801,
-        1108740299
+        1108740299,
+        85672801
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890523901,
-    "wof:lastmodified":1566726471,
-    "wof:name":"T\u014dkai-mura",
+    "wof:lastmodified":1730094988,
+    "wof:name":"T\u014dkai",
     "wof:parent_id":1108740299,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/903/890523903.geojson
+++ b/data/890/523/903/890523903.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Sumita"
+    ],
+    "name:eng_x_variant":[
+        "Sumita-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u4f4f\u7530\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672839,
-        1108739971
+        1108739971,
+        85672839
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890523903,
-    "wof:lastmodified":1566726479,
-    "wof:name":"Sumita-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Sumita",
     "wof:parent_id":1108739971,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/919/890523919.geojson
+++ b/data/890/523/919/890523919.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yakumo"
+    ],
+    "name:eng_x_variant":[
+        "Yakumo-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u516b\u96f2\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739549
+        1108739549,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890523919,
-    "wof:lastmodified":1566726485,
-    "wof:name":"Yakumo-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Yakumo",
     "wof:parent_id":1108739549,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/523/925/890523925.geojson
+++ b/data/890/523/925/890523925.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kutchan"
+    ],
+    "name:eng_x_variant":[
+        "Kutchan-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5036\u77e5\u5b89\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739589
+        1108739589,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890523925,
-    "wof:lastmodified":1566726478,
-    "wof:name":"Kutchan-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Kutchan",
     "wof:parent_id":1108739589,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/117/890524117.geojson
+++ b/data/890/524/117/890524117.geojson
@@ -22,6 +22,9 @@
     "name:eng_x_preferred":[
         "Ainan"
     ],
+    "name:eng_x_variant":[
+        "Ainan-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u611b\u5357\u753a"
     ],
@@ -33,8 +36,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672711,
-        1108742937
+        1108742937,
+        85672711
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +57,8 @@
         }
     ],
     "wof:id":890524117,
-    "wof:lastmodified":1566726496,
-    "wof:name":"Ainan-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Ainan",
     "wof:parent_id":1108742937,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/129/890524129.geojson
+++ b/data/890/524/129/890524129.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kimotsuki"
+    ],
+    "name:eng_x_variant":[
+        "Kimotsuki-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u809d\u4ed8\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672861,
-        1108743337
+        1108743337,
+        85672861
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524129,
-    "wof:lastmodified":1566726495,
-    "wof:name":"Kimotsuki-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Kimotsuki",
     "wof:parent_id":1108743337,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/135/890524135.geojson
+++ b/data/890/524/135/890524135.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kink\u014d"
+    ],
+    "name:eng_x_variant":[
+        "Kink\u014d-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u9326\u6c5f\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672861,
-        1108743333
+        1108743333,
+        85672861
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524135,
-    "wof:lastmodified":1566726486,
-    "wof:name":"Kink\u014d-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Kink\u014d",
     "wof:parent_id":1108743333,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/139/890524139.geojson
+++ b/data/890/524/139/890524139.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yurihama"
+    ],
+    "name:eng_x_variant":[
+        "Yurihama-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u6e6f\u68a8\u6d5c\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672685,
-        1108742693
+        1108742693,
+        85672685
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524139,
-    "wof:lastmodified":1566726498,
-    "wof:name":"Yurihama-ch\u014d",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Yurihama",
     "wof:parent_id":1108742693,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/149/890524149.geojson
+++ b/data/890/524/149/890524149.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kamiita"
+    ],
+    "name:eng_x_variant":[
+        "Kamiita-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u4e0a\u677f\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672729,
-        1108742875
+        1108742875,
+        85672729
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524149,
-    "wof:lastmodified":1566726505,
-    "wof:name":"Kamiita-ch\u014d",
+    "wof:lastmodified":1730094990,
+    "wof:name":"Kamiita",
     "wof:parent_id":1108742875,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/153/890524153.geojson
+++ b/data/890/524/153/890524153.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kikuy\u014d"
+    ],
+    "name:eng_x_variant":[
+        "Kikuy\u014d-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u83ca\u967d\u753a"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672703,
-        1108743177
+        1108743177,
+        85672703
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890524153,
-    "wof:lastmodified":1566726496,
-    "wof:name":"Kikuy\u014d-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Kikuy\u014d",
     "wof:parent_id":1108743177,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/155/890524155.geojson
+++ b/data/890/524/155/890524155.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Minamioso"
+    ],
+    "name:eng_x_variant":[
+        "Minamioso-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u5357\u963f\u8607\u6751"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672703,
-        1108743191
+        1108743191,
+        85672703
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890524155,
-    "wof:lastmodified":1566726498,
-    "wof:name":"Minamioso-mura",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Minamioso",
     "wof:parent_id":1108743191,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/157/890524157.geojson
+++ b/data/890/524/157/890524157.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Mashiki"
+    ],
+    "name:eng_x_variant":[
+        "Mashiki-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u76ca\u57ce\u753a"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672703,
-        1108743197
+        1108743197,
+        85672703
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890524157,
-    "wof:lastmodified":1566726487,
-    "wof:name":"Mashiki-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Mashiki",
     "wof:parent_id":1108743197,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/159/890524159.geojson
+++ b/data/890/524/159/890524159.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Hikawa"
+    ],
+    "name:eng_x_variant":[
+        "Hikawa-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u6c37\u5ddd\u753a"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672703,
-        1108743205
+        1108743205,
+        85672703
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890524159,
-    "wof:lastmodified":1566726487,
-    "wof:name":"Hikawa-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Hikawa",
     "wof:parent_id":1108743205,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/163/890524163.geojson
+++ b/data/890/524/163/890524163.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Mimata"
+    ],
+    "name:eng_x_variant":[
+        "Mimata-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u4e09\u80a1\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672707,
-        1108743267
+        1108743267,
+        85672707
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524163,
-    "wof:lastmodified":1566726497,
-    "wof:name":"Mimata-ch\u014d",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Mimata",
     "wof:parent_id":1108743267,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/165/890524165.geojson
+++ b/data/890/524/165/890524165.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kawaminami"
+    ],
+    "name:eng_x_variant":[
+        "Kawaminami-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5ddd\u5357\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672707,
-        1108743285
+        1108743285,
+        85672707
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524165,
-    "wof:lastmodified":1566726497,
-    "wof:name":"Kawaminami-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Kawaminami",
     "wof:parent_id":1108743285,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/167/890524167.geojson
+++ b/data/890/524/167/890524167.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Tsuno"
+    ],
+    "name:eng_x_variant":[
+        "Tsuno-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u90fd\u8fb2\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672707,
-        1108743287
+        1108743287,
+        85672707
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524167,
-    "wof:lastmodified":1566726488,
-    "wof:name":"Tsuno-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Tsuno",
     "wof:parent_id":1108743287,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/169/890524169.geojson
+++ b/data/890/524/169/890524169.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kadogawa"
+    ],
+    "name:eng_x_variant":[
+        "Kadogawa-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u9580\u5ddd\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672707,
-        1108743289
+        1108743289,
+        85672707
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524169,
-    "wof:lastmodified":1566726489,
-    "wof:name":"Kadogawa-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Kadogawa",
     "wof:parent_id":1108743289,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/171/890524171.geojson
+++ b/data/890/524/171/890524171.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Hinokage"
+    ],
+    "name:eng_x_variant":[
+        "Hinokage-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u65e5\u4e4b\u5f71\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672707,
-        1108743301
+        1108743301,
+        85672707
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524171,
-    "wof:lastmodified":1566726505,
-    "wof:name":"Hinokage-ch\u014d",
+    "wof:lastmodified":1730094990,
+    "wof:name":"Hinokage",
     "wof:parent_id":1108743301,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/173/890524173.geojson
+++ b/data/890/524/173/890524173.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kokonoe"
+    ],
+    "name:eng_x_variant":[
+        "Kokonoe-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u4e5d\u91cd\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672723,
-        1108743253
+        1108743253,
+        85672723
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524173,
-    "wof:lastmodified":1566726494,
-    "wof:name":"Kokonoe-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Kokonoe",
     "wof:parent_id":1108743253,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/175/890524175.geojson
+++ b/data/890/524/175/890524175.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Shimosuwa"
+    ],
+    "name:eng_x_variant":[
+        "Shimosuwa-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u4e0b\u8acf\u8a2a\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672749,
-        1108742019
+        1108742019,
+        85672749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524175,
-    "wof:lastmodified":1566726495,
-    "wof:name":"Shimosuwa-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Shimosuwa",
     "wof:parent_id":1108742019,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/177/890524177.geojson
+++ b/data/890/524/177/890524177.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Minowa"
+    ],
+    "name:eng_x_variant":[
+        "Minowa-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u7b95\u8f2a\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672749,
-        1108742027
+        1108742027,
+        85672749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524177,
-    "wof:lastmodified":1566726504,
-    "wof:name":"Minowa-machi",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Minowa",
     "wof:parent_id":1108742027,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/181/890524181.geojson
+++ b/data/890/524/181/890524181.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Takamori"
+    ],
+    "name:eng_x_variant":[
+        "Takamori-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u9ad8\u68ee\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672749,
-        1108742041
+        1108742041,
+        85672749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524181,
-    "wof:lastmodified":1566726495,
-    "wof:name":"Takamori-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Takamori",
     "wof:parent_id":1108742041,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/185/890524185.geojson
+++ b/data/890/524/185/890524185.geojson
@@ -40,6 +40,9 @@
     "name:eng_x_preferred":[
         "Nishiizu"
     ],
+    "name:eng_x_variant":[
+        "Nishiizu-ch\u014d"
+    ],
     "name:fas_x_preferred":[
         "\u0646\u06cc\u0634\u06cc\u200c\u0627\u06cc\u0632\u0648"
     ],
@@ -100,8 +103,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672753,
-        1108742221
+        1108742221,
+        85672753
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -123,8 +126,8 @@
         }
     ],
     "wof:id":890524185,
-    "wof:lastmodified":1690938026,
-    "wof:name":"Nishiizu-ch\u014d",
+    "wof:lastmodified":1730094990,
+    "wof:name":"Nishiizu",
     "wof:parent_id":1108742221,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/201/890524201.geojson
+++ b/data/890/524/201/890524201.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Higashisonogi"
+    ],
+    "name:eng_x_variant":[
+        "Higashisonogi-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u6771\u5f7c\u6775\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672857,
-        1108743141
+        1108743141,
+        85672857
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524201,
-    "wof:lastmodified":1566726502,
-    "wof:name":"Higashisonogi-ch\u014d",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Higashisonogi",
     "wof:parent_id":1108743141,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/203/890524203.geojson
+++ b/data/890/524/203/890524203.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nakasatsunai"
+    ],
+    "name:eng_x_variant":[
+        "Nakasatsunai-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u4e2d\u672d\u5185\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        890520771
+        890520771,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524203,
-    "wof:lastmodified":1566726493,
-    "wof:name":"Nakasatsunai-mura",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Nakasatsunai",
     "wof:parent_id":890520771,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/205/890524205.geojson
+++ b/data/890/524/205/890524205.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nakashibetsu"
+    ],
+    "name:eng_x_variant":[
+        "Nakashibetsu-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u4e2d\u6a19\u6d25\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739847
+        1108739847,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524205,
-    "wof:lastmodified":1566726494,
-    "wof:name":"Nakashibetsu-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Nakashibetsu",
     "wof:parent_id":1108739847,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/207/890524207.geojson
+++ b/data/890/524/207/890524207.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nakatonbetsu"
+    ],
+    "name:eng_x_variant":[
+        "Nakatonbetsu Ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u4e2d\u9813\u5225\u753a"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739707
+        1108739707,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890524207,
-    "wof:lastmodified":1566726501,
-    "wof:name":"Nakatonbetsu Ch\u014d",
+    "wof:lastmodified":1730271560,
+    "wof:name":"Nakatonbetsu",
     "wof:parent_id":1108739707,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/209/890524209.geojson
+++ b/data/890/524/209/890524209.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nanporo"
+    ],
+    "name:eng_x_variant":[
+        "Nanporo-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5357\u5e4c\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739611
+        1108739611,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524209,
-    "wof:lastmodified":1566726501,
-    "wof:name":"Nanporo-ch\u014d",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Nanporo",
     "wof:parent_id":1108739611,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/213/890524213.geojson
+++ b/data/890/524/213/890524213.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Numata"
+    ],
+    "name:eng_x_variant":[
+        "Numata-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u6cbc\u7530\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739641
+        1108739641,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524213,
-    "wof:lastmodified":1566726501,
-    "wof:name":"Numata-ch\u014d",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Numata",
     "wof:parent_id":1108739641,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/217/890524217.geojson
+++ b/data/890/524/217/890524217.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Otoineppu"
+    ],
+    "name:eng_x_variant":[
+        "Otoineppu Mura"
+    ],
     "name:jpn_x_preferred":[
         "\u97f3\u5a01\u5b50\u5e9c\u6751"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739681
+        1108739681,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890524217,
-    "wof:lastmodified":1566726491,
-    "wof:name":"Otoineppu Mura",
+    "wof:lastmodified":1730271560,
+    "wof:name":"Otoineppu",
     "wof:parent_id":1108739681,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/219/890524219.geojson
+++ b/data/890/524/219/890524219.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Takasu"
+    ],
+    "name:eng_x_variant":[
+        "Takasu-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u9df9\u6816\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739643
+        1108739643,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524219,
-    "wof:lastmodified":1566726491,
-    "wof:name":"Takasu-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Takasu",
     "wof:parent_id":1108739643,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/221/890524221.geojson
+++ b/data/890/524/221/890524221.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kawanishi"
+    ],
+    "name:eng_x_variant":[
+        "Kawanishi-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5ddd\u897f\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672853,
-        1108741179
+        1108741179,
+        85672853
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524221,
-    "wof:lastmodified":1566726490,
-    "wof:name":"Kawanishi-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Kawanishi",
     "wof:parent_id":1108741179,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/229/890524229.geojson
+++ b/data/890/524/229/890524229.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nakayama"
+    ],
+    "name:eng_x_variant":[
+        "Nakayama-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u4e2d\u5c71\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672853,
-        1108740109
+        1108740109,
+        85672853
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524229,
-    "wof:lastmodified":1566726489,
-    "wof:name":"Nakayama-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Nakayama",
     "wof:parent_id":1108740109,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/231/890524231.geojson
+++ b/data/890/524/231/890524231.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "\u014ce"
+    ],
+    "name:eng_x_variant":[
+        "\u014ce-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5927\u6c5f\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672853,
-        1108740117
+        1108740117,
+        85672853
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524231,
-    "wof:lastmodified":1566726501,
-    "wof:name":"\u014ce-machi",
+    "wof:lastmodified":1730094989,
+    "wof:name":"\u014ce",
     "wof:parent_id":1108740117,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/235/890524235.geojson
+++ b/data/890/524/235/890524235.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Goka"
+    ],
+    "name:eng_x_variant":[
+        "Goka-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u4e94\u971e\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672801,
-        1108740313
+        1108740313,
+        85672801
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524235,
-    "wof:lastmodified":1566726492,
-    "wof:name":"Goka-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Goka",
     "wof:parent_id":1108740313,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/245/890524245.geojson
+++ b/data/890/524/245/890524245.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Miho"
+    ],
+    "name:eng_x_variant":[
+        "Miho-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u7f8e\u6d66\u6751"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672801,
-        1108740305
+        1108740305,
+        85672801
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524245,
-    "wof:lastmodified":1566726490,
-    "wof:name":"Miho-mura",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Miho",
     "wof:parent_id":1108740305,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/249/890524249.geojson
+++ b/data/890/524/249/890524249.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yachiyo"
+    ],
+    "name:eng_x_variant":[
+        "Yachiyo-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u516b\u5343\u4ee3\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672801,
-        1108740311
+        1108740311,
+        85672801
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524249,
-    "wof:lastmodified":1566726500,
-    "wof:name":"Yachiyo-machi",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Yachiyo",
     "wof:parent_id":1108740311,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/253/890524253.geojson
+++ b/data/890/524/253/890524253.geojson
@@ -34,6 +34,9 @@
     "name:eng_x_preferred":[
         "Iwafune"
     ],
+    "name:eng_x_variant":[
+        "Iwafune-machi"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u06cc\u0648\u0627\u0641\u0648\u0646\u0647"
     ],
@@ -91,8 +94,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672813,
-        890520383
+        890520383,
+        85672813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -114,8 +117,8 @@
         }
     ],
     "wof:id":890524253,
-    "wof:lastmodified":1690938012,
-    "wof:name":"Iwafune-machi",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Iwafune",
     "wof:parent_id":890520383,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/255/890524255.geojson
+++ b/data/890/524/255/890524255.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Matsubushi"
+    ],
+    "name:eng_x_variant":[
+        "Matsubushi-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u677e\u4f0f\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672807,
-        1108740529
+        1108740529,
+        85672807
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524255,
-    "wof:lastmodified":1566726503,
-    "wof:name":"Matsubushi-machi",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Matsubushi",
     "wof:parent_id":1108740529,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/263/890524263.geojson
+++ b/data/890/524/263/890524263.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yuzawa"
+    ],
+    "name:eng_x_variant":[
+        "Yuzawa-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u6e6f\u6ca2\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672849,
-        1108741853
+        1108741853,
+        85672849
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524263,
-    "wof:lastmodified":1566726502,
-    "wof:name":"Yuzawa-machi",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Yuzawa",
     "wof:parent_id":1108741853,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/265/890524265.geojson
+++ b/data/890/524/265/890524265.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Minamiechizen"
+    ],
+    "name:eng_x_variant":[
+        "Minamiechizen-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5357\u8d8a\u524d\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672767,
-        1108741917
+        1108741917,
+        85672767
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524265,
-    "wof:lastmodified":1566726502,
-    "wof:name":"Minamiechizen-ch\u014d",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Minamiechizen",
     "wof:parent_id":1108741917,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/267/890524267.geojson
+++ b/data/890/524/267/890524267.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Mihama"
+    ],
+    "name:eng_x_variant":[
+        "Mihama-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u7f8e\u6d5c\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672767,
-        1108741921
+        1108741921,
+        85672767
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524267,
-    "wof:lastmodified":1566726493,
-    "wof:name":"Mihama-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Mihama",
     "wof:parent_id":1108741921,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/273/890524273.geojson
+++ b/data/890/524/273/890524273.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nakanoto"
+    ],
+    "name:eng_x_variant":[
+        "Nakanoto-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u4e2d\u80fd\u767b\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672741,
-        1108741895
+        1108741895,
+        85672741
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524273,
-    "wof:lastmodified":1566726490,
-    "wof:name":"Nakanoto-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Nakanoto",
     "wof:parent_id":1108741895,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/295/890524295.geojson
+++ b/data/890/524/295/890524295.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yonabaru"
+    ],
+    "name:eng_x_variant":[
+        "Yonabaru-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u4e0e\u90a3\u539f\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672867,
-        1108743419
+        1108743419,
+        85672867
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524295,
-    "wof:lastmodified":1566726492,
-    "wof:name":"Yonabaru-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Yonabaru",
     "wof:parent_id":1108743419,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/297/890524297.geojson
+++ b/data/890/524/297/890524297.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yomitan"
+    ],
+    "name:eng_x_variant":[
+        "Yomitan-son"
+    ],
     "name:jpn_x_preferred":[
         "\u8aad\u8c37\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672867,
-        1108743405
+        1108743405,
+        85672867
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524297,
-    "wof:lastmodified":1566726502,
-    "wof:name":"Yomitan-son",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Yomitan",
     "wof:parent_id":1108743405,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/299/890524299.geojson
+++ b/data/890/524/299/890524299.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yamanakako"
+    ],
+    "name:eng_x_variant":[
+        "Yamanakako-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u5c71\u4e2d\u6e56\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672821,
-        1108741965
+        1108741965,
+        85672821
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524299,
-    "wof:lastmodified":1566726503,
-    "wof:name":"Yamanakako-mura",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Yamanakako",
     "wof:parent_id":1108741965,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/365/890524365.geojson
+++ b/data/890/524/365/890524365.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "\u014cyodo"
+    ],
+    "name:eng_x_variant":[
+        "\u014cyodo-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5927\u6dc0\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672779,
-        1108742605
+        1108742605,
+        85672779
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524365,
-    "wof:lastmodified":1566726487,
-    "wof:name":"\u014cyodo-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"\u014cyodo",
     "wof:parent_id":1108742605,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/433/890524433.geojson
+++ b/data/890/524/433/890524433.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Inuyama"
+    ],
+    "name:eng_x_variant":[
+        "Inuyama-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u72ac\u5c71\u5e02"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672731,
-        1108742287
+        1108742287,
+        85672731
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890524433,
-    "wof:lastmodified":1566726502,
-    "wof:name":"Inuyama-ch\u014d",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Inuyama",
     "wof:parent_id":1108742287,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/443/890524443.geojson
+++ b/data/890/524/443/890524443.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Hinohara"
+    ],
+    "name:eng_x_variant":[
+        "Hinohara-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u6a9c\u539f\u6751"
     ],
@@ -30,8 +36,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672817,
-        1108741759
+        1108741759,
+        85672817
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -51,8 +57,8 @@
         }
     ],
     "wof:id":890524443,
-    "wof:lastmodified":1566726499,
-    "wof:name":"Hinohara-mura",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Hinohara",
     "wof:parent_id":1108741759,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/481/890524481.geojson
+++ b/data/890/524/481/890524481.geojson
@@ -37,6 +37,9 @@
     "name:eng_x_preferred":[
         "Asuka"
     ],
+    "name:eng_x_variant":[
+        "Asuka-mura"
+    ],
     "name:fas_x_preferred":[
         "\u0622\u0633\u0648\u06a9\u0627"
     ],
@@ -109,8 +112,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672779,
-        1108742593
+        1108742593,
+        85672779
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -132,8 +135,8 @@
         }
     ],
     "wof:id":890524481,
-    "wof:lastmodified":1690938006,
-    "wof:name":"Asuka-mura",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Asuka",
     "wof:parent_id":1108742593,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/491/890524491.geojson
+++ b/data/890/524/491/890524491.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Chatan"
+    ],
+    "name:eng_x_variant":[
+        "Chatan-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5317\u8c37\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672867,
-        1108743409
+        1108743409,
+        85672867
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524491,
-    "wof:lastmodified":1566726494,
-    "wof:name":"Chatan-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Chatan",
     "wof:parent_id":1108743409,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/527/890524527.geojson
+++ b/data/890/524/527/890524527.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nasu"
+    ],
+    "name:eng_x_variant":[
+        "Nasu-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u90a3\u9808\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672813,
-        1108740353
+        1108740353,
+        85672813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524527,
-    "wof:lastmodified":1566726495,
-    "wof:name":"Nasu-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Nasu",
     "wof:parent_id":1108740353,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/577/890524577.geojson
+++ b/data/890/524/577/890524577.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yatomi"
+    ],
+    "name:eng_x_variant":[
+        "Yatomi-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5f25\u5bcc\u5e02"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672731,
-        1108742273
+        1108742273,
+        85672731
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524577,
-    "wof:lastmodified":1566726505,
-    "wof:name":"Yatomi-ch\u014d",
+    "wof:lastmodified":1730094990,
+    "wof:name":"Yatomi",
     "wof:parent_id":1108742273,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/637/890524637.geojson
+++ b/data/890/524/637/890524637.geojson
@@ -20,6 +20,10 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "name:eng_x_preferred":[
+        "\u014cji"
+    ],
+    "name:eng_x_variant":[
+        "\u014cji-ch\u014d",
         "Oji-cho"
     ],
     "name:jpn_x_preferred":[
@@ -36,8 +40,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672779,
-        1108742597
+        1108742597,
+        85672779
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +61,8 @@
         }
     ],
     "wof:id":890524637,
-    "wof:lastmodified":1566726501,
-    "wof:name":"\u014cji-ch\u014d",
+    "wof:lastmodified":1730094989,
+    "wof:name":"\u014cji",
     "wof:parent_id":1108742597,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/679/890524679.geojson
+++ b/data/890/524/679/890524679.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kadena"
+    ],
+    "name:eng_x_variant":[
+        "Kadena-son"
+    ],
     "name:jpn_x_preferred":[
         "\u5609\u624b\u7d0d\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672867,
-        1108743407
+        1108743407,
+        85672867
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524679,
-    "wof:lastmodified":1566726500,
-    "wof:name":"Kadena-son",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Kadena",
     "wof:parent_id":1108743407,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/705/890524705.geojson
+++ b/data/890/524/705/890524705.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Hidaka"
+    ],
+    "name:eng_x_variant":[
+        "Hidaka-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u65e5\u9ad8\u753a"
     ],
@@ -30,8 +36,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672807,
-        1108740475
+        1108740475,
+        85672807
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -51,8 +57,8 @@
         }
     ],
     "wof:id":890524705,
-    "wof:lastmodified":1566726496,
-    "wof:name":"Hidaka-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Hidaka",
     "wof:parent_id":1108740475,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/741/890524741.geojson
+++ b/data/890/524/741/890524741.geojson
@@ -20,6 +20,10 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "name:eng_x_preferred":[
+        "Kami"
+    ],
+    "name:eng_x_variant":[
+        "Kami-ch\u014d",
         "Kami-cho"
     ],
     "name:jpn_x_preferred":[
@@ -36,8 +40,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672769,
-        1108742551
+        1108742551,
+        85672769
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +61,8 @@
         }
     ],
     "wof:id":890524741,
-    "wof:lastmodified":1566726496,
-    "wof:name":"Kami-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Kami",
     "wof:parent_id":1108742551,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/745/890524745.geojson
+++ b/data/890/524/745/890524745.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kamiichi"
+    ],
+    "name:eng_x_variant":[
+        "Kamiichi-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u4e0a\u5e02\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672759,
-        1108741871
+        1108741871,
+        85672759
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524745,
-    "wof:lastmodified":1566726505,
-    "wof:name":"Kamiichi-machi",
+    "wof:lastmodified":1730094990,
+    "wof:name":"Kamiichi",
     "wof:parent_id":1108741871,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/749/890524749.geojson
+++ b/data/890/524/749/890524749.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Su\u014d\u014dshima"
+    ],
+    "name:eng_x_variant":[
+        "Su\u014d\u014dshima-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5468\u9632\u5927\u5cf6\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672689,
-        1108742831
+        1108742831,
+        85672689
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524749,
-    "wof:lastmodified":1566726495,
-    "wof:name":"Su\u014d\u014dshima-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Su\u014d\u014dshima",
     "wof:parent_id":1108742831,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/751/890524751.geojson
+++ b/data/890/524/751/890524751.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Aish\u014d"
+    ],
+    "name:eng_x_variant":[
+        "Aish\u014d-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u611b\u8358\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672789,
-        1108742383
+        1108742383,
+        85672789
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524751,
-    "wof:lastmodified":1566726497,
-    "wof:name":"Aish\u014d-ch\u014d",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Aish\u014d",
     "wof:parent_id":1108742383,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/753/890524753.geojson
+++ b/data/890/524/753/890524753.geojson
@@ -22,6 +22,9 @@
     "name:eng_x_preferred":[
         "Hino"
     ],
+    "name:eng_x_variant":[
+        "Hino-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u65e5\u91ce\u753a"
     ],
@@ -36,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672789,
-        1108742379
+        1108742379,
+        85672789
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +60,8 @@
         }
     ],
     "wof:id":890524753,
-    "wof:lastmodified":1566726488,
-    "wof:name":"Hino-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Hino",
     "wof:parent_id":1108742379,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/757/890524757.geojson
+++ b/data/890/524/757/890524757.geojson
@@ -22,6 +22,9 @@
     "name:eng_x_preferred":[
         "Takatsuki"
     ],
+    "name:eng_x_variant":[
+        "Takatsuki-ch\u014d"
+    ],
     "name:fra_x_preferred":[
         "Takatsuki"
     ],
@@ -52,8 +55,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672789,
-        890520323
+        890520323,
+        85672789
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -75,8 +78,8 @@
         }
     ],
     "wof:id":890524757,
-    "wof:lastmodified":1690938001,
-    "wof:name":"Takatsuki-ch\u014d",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Takatsuki",
     "wof:parent_id":890520323,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/783/890524783.geojson
+++ b/data/890/524/783/890524783.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Sasaguri"
+    ],
+    "name:eng_x_variant":[
+        "Sasaguri-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u7be0\u6817\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672697,
-        1108743031
+        1108743031,
+        85672697
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524783,
-    "wof:lastmodified":1566726496,
-    "wof:name":"Sasaguri-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Sasaguri",
     "wof:parent_id":1108743031,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/785/890524785.geojson
+++ b/data/890/524/785/890524785.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Shime"
+    ],
+    "name:eng_x_variant":[
+        "Shime-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5fd7\u514d\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672697,
-        1108743033
+        1108743033,
+        85672697
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524785,
-    "wof:lastmodified":1566726495,
-    "wof:name":"Shime-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Shime",
     "wof:parent_id":1108743033,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/801/890524801.geojson
+++ b/data/890/524/801/890524801.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kanda"
+    ],
+    "name:eng_x_variant":[
+        "Kanda-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u82c5\u7530\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672697,
-        1108743087
+        1108743087,
+        85672697
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524801,
-    "wof:lastmodified":1566726502,
-    "wof:name":"Kanda-machi",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Kanda",
     "wof:parent_id":1108743087,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/803/890524803.geojson
+++ b/data/890/524/803/890524803.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Miyako"
+    ],
+    "name:eng_x_variant":[
+        "Miyako-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u307f\u3084\u3053\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672697,
-        1108743089
+        1108743089,
+        85672697
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524803,
-    "wof:lastmodified":1566726493,
-    "wof:name":"Miyako-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Miyako",
     "wof:parent_id":1108743089,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/805/890524805.geojson
+++ b/data/890/524/805/890524805.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kawai"
+    ],
+    "name:eng_x_variant":[
+        "Kawai-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u6cb3\u5408\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672779,
-        1108742601
+        1108742601,
+        85672779
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524805,
-    "wof:lastmodified":1566726494,
-    "wof:name":"Kawai-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Kawai",
     "wof:parent_id":1108742601,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/807/890524807.geojson
+++ b/data/890/524/807/890524807.geojson
@@ -37,6 +37,9 @@
     "name:eng_x_preferred":[
         "Kurotaki"
     ],
+    "name:eng_x_variant":[
+        "Kurotaki-mura"
+    ],
     "name:fas_x_preferred":[
         "\u06a9\u0648\u0631\u0648\u062a\u0627\u06a9\u06cc"
     ],
@@ -91,8 +94,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672779,
-        1108742611
+        1108742611,
+        85672779
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -114,8 +117,8 @@
         }
     ],
     "wof:id":890524807,
-    "wof:lastmodified":1690938011,
-    "wof:name":"Kurotaki-mura",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Kurotaki",
     "wof:parent_id":1108742611,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/811/890524811.geojson
+++ b/data/890/524/811/890524811.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "K\u014dry\u014d"
+    ],
+    "name:eng_x_variant":[
+        "K\u014dry\u014d-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "K\u014dry\u014d-ch\u014d"
     ],
@@ -35,8 +41,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672779,
-        1108742599
+        1108742599,
+        85672779
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -56,8 +62,8 @@
         }
     ],
     "wof:id":890524811,
-    "wof:lastmodified":1566726490,
-    "wof:name":"K\u014dry\u014d-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"K\u014dry\u014d",
     "wof:parent_id":1108742599,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/823/890524823.geojson
+++ b/data/890/524/823/890524823.geojson
@@ -43,6 +43,9 @@
     "name:eng_x_preferred":[
         "Ichikawamisato"
     ],
+    "name:eng_x_variant":[
+        "Ichikawamisato-ch\u014d"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u06cc\u0686\u06cc\u06a9\u0627\u0648\u0627\u0645\u06cc\u0633\u0627\u062a\u0648"
     ],
@@ -112,8 +115,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672821,
-        1108741945
+        1108741945,
+        85672821
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -135,8 +138,8 @@
         }
     ],
     "wof:id":890524823,
-    "wof:lastmodified":1690938004,
-    "wof:name":"Ichikawamisato-ch\u014d",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Ichikawamisato",
     "wof:parent_id":1108741945,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/825/890524825.geojson
+++ b/data/890/524/825/890524825.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Narusawa"
+    ],
+    "name:eng_x_variant":[
+        "Narusawa-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u9cf4\u6ca2\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672821,
-        1108741967
+        1108741967,
+        85672821
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524825,
-    "wof:lastmodified":1566726500,
-    "wof:name":"Narusawa-mura",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Narusawa",
     "wof:parent_id":1108741967,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/829/890524829.geojson
+++ b/data/890/524/829/890524829.geojson
@@ -43,6 +43,9 @@
     "name:eng_x_preferred":[
         "Fujikawaguchiko"
     ],
+    "name:eng_x_variant":[
+        "Fujikawaguchiko-machi"
+    ],
     "name:fas_x_preferred":[
         "\u0641\u0648\u062c\u06cc\u06a9\u0627\u0648\u0627\u06af\u0648\u0686\u06cc\u06a9\u0648"
     ],
@@ -121,8 +124,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672821,
-        1108741969
+        1108741969,
+        85672821
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -144,8 +147,8 @@
         }
     ],
     "wof:id":890524829,
-    "wof:lastmodified":1690937976,
-    "wof:name":"Fujikawaguchiko-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Fujikawaguchiko",
     "wof:parent_id":1108741969,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/833/890524833.geojson
+++ b/data/890/524/833/890524833.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Iizuna"
+    ],
+    "name:eng_x_variant":[
+        "Iizuna-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u98ef\u7db1\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672749,
-        1108742119
+        1108742119,
+        85672749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524833,
-    "wof:lastmodified":1566726494,
-    "wof:name":"Iizuna-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Iizuna",
     "wof:parent_id":1108742119,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/837/890524837.geojson
+++ b/data/890/524/837/890524837.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Mihama"
+    ],
+    "name:eng_x_variant":[
+        "Mihama-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5fa1\u6d5c\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672745,
-        1108742357
+        1108742357,
+        85672745
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524837,
-    "wof:lastmodified":1566726502,
-    "wof:name":"Mihama-ch\u014d",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Mihama",
     "wof:parent_id":1108742357,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/839/890524839.geojson
+++ b/data/890/524/839/890524839.geojson
@@ -43,6 +43,9 @@
     "name:eng_x_preferred":[
         "Minamiise"
     ],
+    "name:eng_x_variant":[
+        "Minamiise-ch\u014d"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u06cc\u0646\u0627\u0645\u06cc\u200c\u0627\u06cc\u0633\u0647"
     ],
@@ -106,8 +109,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672745,
-        1108742351
+        1108742351,
+        85672745
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -129,8 +132,8 @@
         }
     ],
     "wof:id":890524839,
-    "wof:lastmodified":1690938015,
-    "wof:name":"Minamiise-ch\u014d",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Minamiise",
     "wof:parent_id":1108742351,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/841/890524841.geojson
+++ b/data/890/524/841/890524841.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nozawaonsen"
+    ],
+    "name:eng_x_variant":[
+        "Nozawaonsen-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u91ce\u6ca2\u6e29\u6cc9\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672749,
-        1108742113
+        1108742113,
+        85672749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524841,
-    "wof:lastmodified":1566726499,
-    "wof:name":"Nozawaonsen-mura",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Nozawaonsen",
     "wof:parent_id":1108742113,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/855/890524855.geojson
+++ b/data/890/524/855/890524855.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Shirakawa"
+    ],
+    "name:eng_x_variant":[
+        "Shirakawa-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u767d\u5ddd\u6751"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672735,
-        1108742183
+        1108742183,
+        85672735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524855,
-    "wof:lastmodified":1566726502,
-    "wof:name":"Shirakawa-mura",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Shirakawa",
     "wof:parent_id":1108742183,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/867/890524867.geojson
+++ b/data/890/524/867/890524867.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Rankoshi"
+    ],
+    "name:eng_x_variant":[
+        "Rankoshi-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u862d\u8d8a\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739575
+        1108739575,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524867,
-    "wof:lastmodified":1566726493,
-    "wof:name":"Rankoshi-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Rankoshi",
     "wof:parent_id":1108739575,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/869/890524869.geojson
+++ b/data/890/524/869/890524869.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Rusutsu"
+    ],
+    "name:eng_x_variant":[
+        "Rusutsu-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u7559\u5bff\u90fd\u6751"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739581
+        1108739581,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524869,
-    "wof:lastmodified":1566726493,
-    "wof:name":"Rusutsu-mura",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Rusutsu",
     "wof:parent_id":1108739581,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/871/890524871.geojson
+++ b/data/890/524/871/890524871.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Shakotan"
+    ],
+    "name:eng_x_variant":[
+        "Shakotan-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u7a4d\u4e39\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739599
+        1108739599,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524871,
-    "wof:lastmodified":1566726500,
-    "wof:name":"Shakotan-ch\u014d",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Shakotan",
     "wof:parent_id":1108739599,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/873/890524873.geojson
+++ b/data/890/524/873/890524873.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Shimizu"
+    ],
+    "name:eng_x_variant":[
+        "Shimizu-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u6e05\u6c34\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739803
+        1108739803,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524873,
-    "wof:lastmodified":1566726490,
-    "wof:name":"Shimizu-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Shimizu",
     "wof:parent_id":1108739803,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/875/890524875.geojson
+++ b/data/890/524/875/890524875.geojson
@@ -34,6 +34,9 @@
     "name:eng_x_preferred":[
         "Shimukappu"
     ],
+    "name:eng_x_variant":[
+        "Shimukappu-mura"
+    ],
     "name:fas_x_preferred":[
         "\u0634\u06cc\u0645\u0648\u06a9\u0627\u067e\u0648"
     ],
@@ -103,8 +106,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739669
+        1108739669,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -126,8 +129,8 @@
         }
     ],
     "wof:id":890524875,
-    "wof:lastmodified":1690937981,
-    "wof:name":"Shimukappu-mura",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Shimukappu",
     "wof:parent_id":1108739669,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/877/890524877.geojson
+++ b/data/890/524/877/890524877.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Shinhidaka"
+    ],
+    "name:eng_x_variant":[
+        "Shinhidaka-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u65b0\u3072\u3060\u304b\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739787
+        1108739787,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524877,
-    "wof:lastmodified":1566726499,
-    "wof:name":"Shinhidaka-ch\u014d",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Shinhidaka",
     "wof:parent_id":1108739787,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/879/890524879.geojson
+++ b/data/890/524/879/890524879.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Shiranuka"
+    ],
+    "name:eng_x_variant":[
+        "Shiranuka-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u767d\u7ce0\u753a"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739843
+        1108739843,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890524879,
-    "wof:lastmodified":1566726499,
-    "wof:name":"Shiranuka-ch\u014d",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Shiranuka",
     "wof:parent_id":1108739843,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/901/890524901.geojson
+++ b/data/890/524/901/890524901.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Furudono"
+    ],
+    "name:eng_x_variant":[
+        "Furudono-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u53e4\u6bbf\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672835,
-        1108740243
+        1108740243,
+        85672835
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524901,
-    "wof:lastmodified":1566726487,
-    "wof:name":"Furudono-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Furudono",
     "wof:parent_id":1108740243,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/903/890524903.geojson
+++ b/data/890/524/903/890524903.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nogi"
+    ],
+    "name:eng_x_variant":[
+        "Nogi-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u91ce\u6728\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672813,
-        1108740347
+        1108740347,
+        85672813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524903,
-    "wof:lastmodified":1566726497,
-    "wof:name":"Nogi-machi",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Nogi",
     "wof:parent_id":1108740347,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/905/890524905.geojson
+++ b/data/890/524/905/890524905.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Shioya"
+    ],
+    "name:eng_x_variant":[
+        "Shioya-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5869\u8c37\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672813,
-        1108740349
+        1108740349,
+        85672813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524905,
-    "wof:lastmodified":1566726498,
-    "wof:name":"Shioya-machi",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Shioya",
     "wof:parent_id":1108740349,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/907/890524907.geojson
+++ b/data/890/524/907/890524907.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "\u014cizumi"
+    ],
+    "name:eng_x_variant":[
+        "\u014cizumi-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5927\u6cc9\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672871,
-        1108740417
+        1108740417,
+        85672871
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524907,
-    "wof:lastmodified":1566726487,
-    "wof:name":"\u014cizumi-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"\u014cizumi",
     "wof:parent_id":1108740417,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/909/890524909.geojson
+++ b/data/890/524/909/890524909.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Miyashiro"
+    ],
+    "name:eng_x_variant":[
+        "Miyashiro-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u5bae\u4ee3\u753a"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672807,
-        1108740523
+        1108740523,
+        85672807
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890524909,
-    "wof:lastmodified":1566726486,
-    "wof:name":"Miyashiro-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Miyashiro",
     "wof:parent_id":1108740523,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/967/890524967.geojson
+++ b/data/890/524/967/890524967.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "H\u014dki"
+    ],
+    "name:eng_x_variant":[
+        "H\u014dki-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u4f2f\u8006\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672685,
-        1108742707
+        1108742707,
+        85672685
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524967,
-    "wof:lastmodified":1566726497,
-    "wof:name":"H\u014dki-ch\u014d",
+    "wof:lastmodified":1730094989,
+    "wof:name":"H\u014dki",
     "wof:parent_id":1108742707,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/969/890524969.geojson
+++ b/data/890/524/969/890524969.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Hokuei"
+    ],
+    "name:eng_x_variant":[
+        "Hokuei-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5317\u6804\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672685,
-        1108742699
+        1108742699,
+        85672685
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890524969,
-    "wof:lastmodified":1566726498,
-    "wof:name":"Hokuei-ch\u014d",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Hokuei",
     "wof:parent_id":1108742699,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/991/890524991.geojson
+++ b/data/890/524/991/890524991.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Onga"
+    ],
+    "name:eng_x_variant":[
+        "Onga-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u9060\u8cc0\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672697,
-        1108743051
+        1108743051,
+        85672697
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524991,
-    "wof:lastmodified":1566726487,
-    "wof:name":"Onga-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Onga",
     "wof:parent_id":1108743051,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/993/890524993.geojson
+++ b/data/890/524/993/890524993.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nakagawa"
+    ],
+    "name:eng_x_variant":[
+        "Nakagawa-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u90a3\u73c2\u5ddd\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672697,
-        1108743027
+        1108743027,
+        85672697
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524993,
-    "wof:lastmodified":1566726497,
-    "wof:name":"Nakagawa-machi",
+    "wof:lastmodified":1730094989,
+    "wof:name":"Nakagawa",
     "wof:parent_id":1108743027,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/997/890524997.geojson
+++ b/data/890/524/997/890524997.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Sue"
+    ],
+    "name:eng_x_variant":[
+        "Sue-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u9808\u6075\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672697,
-        1108743035
+        1108743035,
+        85672697
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524997,
-    "wof:lastmodified":1566726488,
-    "wof:name":"Sue-machi",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Sue",
     "wof:parent_id":1108743035,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/524/999/890524999.geojson
+++ b/data/890/524/999/890524999.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kasagi"
+    ],
+    "name:eng_x_variant":[
+        "Kasagi-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u7b20\u7f6e\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672777,
-        1108742423
+        1108742423,
+        85672777
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890524999,
-    "wof:lastmodified":1566726489,
-    "wof:name":"Kasagi-ch\u014d",
+    "wof:lastmodified":1730094988,
+    "wof:name":"Kasagi",
     "wof:parent_id":1108742423,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/525/013/890525013.geojson
+++ b/data/890/525/013/890525013.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Tomamae"
+    ],
+    "name:eng_x_variant":[
+        "Tomamae Ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u82eb\u524d\u753a"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739693
+        1108739693,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890525013,
-    "wof:lastmodified":1566726439,
-    "wof:name":"Tomamae Ch\u014d",
+    "wof:lastmodified":1730271559,
+    "wof:name":"Tomamae",
     "wof:parent_id":1108739693,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/525/015/890525015.geojson
+++ b/data/890/525/015/890525015.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Toubetsu"
+    ],
+    "name:eng_x_variant":[
+        "Toubetsu-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5f53\u5225\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739531
+        1108739531,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890525015,
-    "wof:lastmodified":1566726438,
-    "wof:name":"Toubetsu-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Toubetsu",
     "wof:parent_id":1108739531,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/525/019/890525019.geojson
+++ b/data/890/525/019/890525019.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nakai"
+    ],
+    "name:eng_x_variant":[
+        "Nakai-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u4e2d\u4e95\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672805,
-        1108741805
+        1108741805,
+        85672805
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890525019,
-    "wof:lastmodified":1566726448,
-    "wof:name":"Nakai-machi",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Nakai",
     "wof:parent_id":1108741805,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/525/021/890525021.geojson
+++ b/data/890/525/021/890525021.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Matsuda"
+    ],
+    "name:eng_x_variant":[
+        "Matsuda-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u677e\u7530\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672805,
-        1108741809
+        1108741809,
+        85672805
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890525021,
-    "wof:lastmodified":1566726449,
-    "wof:name":"Matsuda-machi",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Matsuda",
     "wof:parent_id":1108741809,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/525/063/890525063.geojson
+++ b/data/890/525/063/890525063.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nagashima"
+    ],
+    "name:eng_x_variant":[
+        "Nagashima-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u9577\u5cf6\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672861,
-        1108743323
+        1108743323,
+        85672861
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890525063,
-    "wof:lastmodified":1566726442,
-    "wof:name":"Nagashima-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Nagashima",
     "wof:parent_id":1108743323,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/525/167/890525167.geojson
+++ b/data/890/525/167/890525167.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Misato"
+    ],
+    "name:eng_x_variant":[
+        "Misato-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u7f8e\u90f7\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672679,
-        1108742727
+        1108742727,
+        85672679
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890525167,
-    "wof:lastmodified":1566726438,
-    "wof:name":"Misato-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Misato",
     "wof:parent_id":1108742727,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/525/171/890525171.geojson
+++ b/data/890/525/171/890525171.geojson
@@ -46,6 +46,9 @@
     "name:eng_x_preferred":[
         "Sotogahama"
     ],
+    "name:eng_x_variant":[
+        "Sotogahama-machi"
+    ],
     "name:fas_x_preferred":[
         "\u0633\u0648\u062a\u0648\u06af\u0627\u0647\u0627\u0645\u0627"
     ],
@@ -127,8 +130,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672831,
-        1108739873
+        1108739873,
+        85672831
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -150,8 +153,8 @@
         }
     ],
     "wof:id":890525171,
-    "wof:lastmodified":1690937935,
-    "wof:name":"Sotogahama-machi",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Sotogahama",
     "wof:parent_id":1108739873,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/525/173/890525173.geojson
+++ b/data/890/525/173/890525173.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kunohe"
+    ],
+    "name:eng_x_variant":[
+        "Kunohe-mura"
+    ],
     "name:jpn_x_preferred":[
         "\u4e5d\u6238\u6751"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672839,
-        1108739989
+        1108739989,
+        85672839
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890525173,
-    "wof:lastmodified":1566726443,
-    "wof:name":"Kunohe-mura",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Kunohe",
     "wof:parent_id":1108739989,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/529/427/890529427.geojson
+++ b/data/890/529/427/890529427.geojson
@@ -22,6 +22,9 @@
     "name:eng_x_preferred":[
         "T\u014dg\u014d"
     ],
+    "name:eng_x_variant":[
+        "T\u014dg\u014d-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u6771\u90f7\u753a"
     ],
@@ -33,8 +36,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672731,
-        1108742277
+        1108742277,
+        85672731
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +57,8 @@
         }
     ],
     "wof:id":890529427,
-    "wof:lastmodified":1566726402,
-    "wof:name":"T\u014dg\u014d-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"T\u014dg\u014d",
     "wof:parent_id":1108742277,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/529/441/890529441.geojson
+++ b/data/890/529/441/890529441.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Wakasa"
+    ],
+    "name:eng_x_variant":[
+        "Wakasa-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u82e5\u685c\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672685,
-        1108742685
+        1108742685,
+        85672685
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890529441,
-    "wof:lastmodified":1566726394,
-    "wof:name":"Wakasa-ch\u014d",
+    "wof:lastmodified":1730094987,
+    "wof:name":"Wakasa",
     "wof:parent_id":1108742685,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/532/959/890532959.geojson
+++ b/data/890/532/959/890532959.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kumano"
+    ],
+    "name:eng_x_variant":[
+        "Kumano-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u718a\u91ce\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672671,
-        1108742809
+        1108742809,
+        85672671
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890532959,
-    "wof:lastmodified":1566726285,
-    "wof:name":"Kumano-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Kumano",
     "wof:parent_id":1108742809,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/532/961/890532961.geojson
+++ b/data/890/532/961/890532961.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Umi"
+    ],
+    "name:eng_x_variant":[
+        "Umi-machi"
+    ],
     "qs:name":"Umi-machi",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -27,8 +33,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672697,
-        1108743029
+        1108743029,
+        85672697
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -48,8 +54,8 @@
         }
     ],
     "wof:id":890532961,
-    "wof:lastmodified":1566726284,
-    "wof:name":"Umi-machi",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Umi",
     "wof:parent_id":1108743029,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/532/965/890532965.geojson
+++ b/data/890/532/965/890532965.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Wazuka"
+    ],
+    "name:eng_x_variant":[
+        "Wazuka-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u548c\u675f\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672777,
-        1108742425
+        1108742425,
+        85672777
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890532965,
-    "wof:lastmodified":1566726277,
-    "wof:name":"Wazuka-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Wazuka",
     "wof:parent_id":1108742425,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/532/967/890532967.geojson
+++ b/data/890/532/967/890532967.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yokohama"
+    ],
+    "name:eng_x_variant":[
+        "Yokohama-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u6a2a\u6d5c\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672831,
-        1108739905
+        1108739905,
+        85672831
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890532967,
-    "wof:lastmodified":1566726285,
-    "wof:name":"Yokohama-machi",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Yokohama",
     "wof:parent_id":1108739905,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/532/969/890532969.geojson
+++ b/data/890/532/969/890532969.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kanegasaki"
+    ],
+    "name:eng_x_variant":[
+        "Kanegasaki-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u91d1\u30f6\u5d0e\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672839,
-        1108739967
+        1108739967,
+        85672839
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890532969,
-    "wof:lastmodified":1566726286,
-    "wof:name":"Kanegasaki-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Kanegasaki",
     "wof:parent_id":1108739967,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/532/977/890532977.geojson
+++ b/data/890/532/977/890532977.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yugawara"
+    ],
+    "name:eng_x_variant":[
+        "Yugawara-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u6e6f\u6cb3\u539f\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672805,
-        1108741821
+        1108741821,
+        85672805
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890532977,
-    "wof:lastmodified":1566726282,
-    "wof:name":"Yugawara-machi",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Yugawara",
     "wof:parent_id":1108741821,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/533/217/890533217.geojson
+++ b/data/890/533/217/890533217.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Utazu"
+    ],
+    "name:eng_x_variant":[
+        "Utazu-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u5b87\u591a\u6d25\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672715,
-        1108742899
+        1108742899,
+        85672715
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890533217,
-    "wof:lastmodified":1566726242,
-    "wof:name":"Utazu-ch\u014d",
+    "wof:lastmodified":1730094984,
+    "wof:name":"Utazu",
     "wof:parent_id":1108742899,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/533/893/890533893.geojson
+++ b/data/890/533/893/890533893.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Nagawa"
+    ],
+    "name:eng_x_variant":[
+        "Nagawa-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u9577\u548c\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672749,
-        1108742017
+        1108742017,
+        85672749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890533893,
-    "wof:lastmodified":1566726244,
-    "wof:name":"Nagawa-machi",
+    "wof:lastmodified":1730094984,
+    "wof:name":"Nagawa",
     "wof:parent_id":1108742017,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/533/895/890533895.geojson
+++ b/data/890/533/895/890533895.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Mori"
+    ],
+    "name:eng_x_variant":[
+        "Mori-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u68ee\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672753,
-        1108742237
+        1108742237,
+        85672753
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890533895,
-    "wof:lastmodified":1566726243,
-    "wof:name":"Mori-machi",
+    "wof:lastmodified":1730094984,
+    "wof:name":"Mori",
     "wof:parent_id":1108742237,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/533/897/890533897.geojson
+++ b/data/890/533/897/890533897.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Bifuka"
+    ],
+    "name:eng_x_variant":[
+        "Bifuka Ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u7f8e\u6df1\u753a"
     ],
@@ -37,8 +43,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739679
+        1108739679,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":890533897,
-    "wof:lastmodified":1566726252,
-    "wof:name":"Bifuka Ch\u014d",
+    "wof:lastmodified":1730271558,
+    "wof:name":"Bifuka",
     "wof:parent_id":1108739679,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/535/209/890535209.geojson
+++ b/data/890/535/209/890535209.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Hirono"
+    ],
+    "name:eng_x_variant":[
+        "Hirono-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u6d0b\u91ce\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672839,
-        1108739991
+        1108739991,
+        85672839
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890535209,
-    "wof:lastmodified":1566726274,
-    "wof:name":"Hirono-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Hirono",
     "wof:parent_id":1108739991,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/535/259/890535259.geojson
+++ b/data/890/535/259/890535259.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Shimanto"
+    ],
+    "name:eng_x_variant":[
+        "Shimanto-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u56db\u4e07\u5341\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672717,
-        1108742991
+        1108742991,
+        85672717
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890535259,
-    "wof:lastmodified":1566726271,
-    "wof:name":"Shimanto-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Shimanto",
     "wof:parent_id":1108742991,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/535/261/890535261.geojson
+++ b/data/890/535/261/890535261.geojson
@@ -40,6 +40,9 @@
     "name:eng_x_preferred":[
         "Kuroshio"
     ],
+    "name:eng_x_variant":[
+        "Kuroshio-ch\u014d"
+    ],
     "name:fas_x_preferred":[
         "\u06a9\u0648\u0631\u0648\u0634\u06cc\u0648"
     ],
@@ -97,8 +100,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672717,
-        1108742997
+        1108742997,
+        85672717
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -120,8 +123,8 @@
         }
     ],
     "wof:id":890535261,
-    "wof:lastmodified":1690937791,
-    "wof:name":"Kuroshio-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Kuroshio",
     "wof:parent_id":1108742997,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/535/263/890535263.geojson
+++ b/data/890/535/263/890535263.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Kaiy\u014d"
+    ],
+    "name:eng_x_variant":[
+        "Kaiy\u014d-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u6d77\u967d\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672729,
-        1108742865
+        1108742865,
+        85672729
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890535263,
-    "wof:lastmodified":1566726275,
-    "wof:name":"Kaiy\u014d-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Kaiy\u014d",
     "wof:parent_id":1108742865,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/535/265/890535265.geojson
+++ b/data/890/535/265/890535265.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Mukawa"
+    ],
+    "name:eng_x_variant":[
+        "Mukawa-ch\u014d"
+    ],
     "name:jpn_x_preferred":[
         "\u3080\u304b\u308f\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672761,
-        1108739771
+        1108739771,
+        85672761
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890535265,
-    "wof:lastmodified":1566726275,
-    "wof:name":"Mukawa-ch\u014d",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Mukawa",
     "wof:parent_id":1108739771,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/535/297/890535297.geojson
+++ b/data/890/535/297/890535297.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Yuza"
+    ],
+    "name:eng_x_variant":[
+        "Yuza-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u904a\u4f50\u753a"
     ],
@@ -33,8 +39,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672853,
-        1108740151
+        1108740151,
+        85672853
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":890535297,
-    "wof:lastmodified":1566726275,
-    "wof:name":"Yuza-machi",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Yuza",
     "wof:parent_id":1108740151,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/535/299/890535299.geojson
+++ b/data/890/535/299/890535299.geojson
@@ -46,6 +46,9 @@
     "name:eng_x_preferred":[
         "Aizumisato"
     ],
+    "name:eng_x_variant":[
+        "Aizumisato-machi"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u06cc\u0632\u0648\u0645\u06cc\u0633\u0627\u062a\u0648"
     ],
@@ -112,8 +115,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672835,
-        1108740215
+        1108740215,
+        85672835
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -135,8 +138,8 @@
         }
     ],
     "wof:id":890535299,
-    "wof:lastmodified":1690937795,
-    "wof:name":"Aizumisato-machi",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Aizumisato",
     "wof:parent_id":1108740215,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/535/301/890535301.geojson
+++ b/data/890/535/301/890535301.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Ishikawa"
+    ],
+    "name:eng_x_variant":[
+        "Ishikawa-machi"
+    ],
     "name:jpn_x_preferred":[
         "\u77f3\u5ddd\u753a"
     ],
@@ -36,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632429,
-        85672835,
-        1108740235
+        1108740235,
+        85672835
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":890535301,
-    "wof:lastmodified":1566726269,
-    "wof:name":"Ishikawa-machi",
+    "wof:lastmodified":1730094985,
+    "wof:name":"Ishikawa",
     "wof:parent_id":1108740235,
     "wof:placetype":"localadmin",
     "wof:population":0,


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2207.

This PR updates name properties for names with certain postfixes. The `wof:name` property and English preferred name values were updated to remove postfixes, and English variant names were adjusted/added to store the name with the postfix. Label properties were also updated, when present. No PIP work needed, property edits only.

Number of records updated: 333